### PR TITLE
Go for simple solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,8 +111,7 @@
     "throttle-debounce": "^3.0.1",
     "typescript": "^4.3.5",
     "uid-safe": "^2.1.5",
-    "use-debounce": "^7.0.0",
-    "use-media": "^1.4.0"
+    "use-debounce": "^7.0.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^8.1.0",

--- a/public/js/usabilla.js
+++ b/public/js/usabilla.js
@@ -1,22 +1,22 @@
 /*{literal}<![CDATA[*/ window.lightningjs ||
-  (function(c) {
+  (function (c) {
     function g(b, d) {
       d && (d += (/\?/.test(d) ? '&' : '?') + 'lv=1');
       c[b] ||
-        (function() {
+        (function () {
           var i = window,
             h = document,
             j = b,
             g = h.location.protocol,
             l = 'load',
             k = 0;
-          (function() {
+          (function () {
             function b() {
               a.P(l);
               a.w = 1;
               c[j]('_load');
             }
-            c[j] = function() {
+            c[j] = function () {
               function m() {
                 m.id = e;
                 return c[j].apply(m, arguments);
@@ -25,7 +25,7 @@
                 e = ++k;
               b = this && this != i ? this.id || 0 : 0;
               (a.s = a.s || []).push([e, b, arguments]);
-              m.then = function(b, c, h) {
+              m.then = function (b, c, h) {
                 var d = (a.fh[e] = a.fh[e] || []),
                   j = (a.eh[e] = a.eh[e] || []),
                   f = (a.ph[e] = a.ph[e] || []);
@@ -44,14 +44,14 @@
               ? d.replace(/^\/\//, (g == 'https:' ? g : 'http:') + '//')
               : d;
             a.p = { 0: +new Date() };
-            a.P = function(b) {
+            a.P = function (b) {
               a.p[b] = new Date() - a.p[0];
             };
             a.w && b();
             i.addEventListener
               ? i.addEventListener(l, b, !1)
               : i.attachEvent('on' + l, b);
-            var q = function() {
+            var q = function () {
               function b() {
                 return [
                   '<head></head><',
@@ -126,8 +126,4 @@
       k = (window[o] = g(o));
     k.require = g;
     k.modules = c;
-  })({});
-window.usabilla_live = lightningjs.require(
-  'usabilla_live',
-  'https://w.usabilla.com/e8b4abda34ab.js'
-); /*]]>{/literal}*/
+  })({}); /*]]>{/literal}*/

--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import { useSessionApi, useSessionValue } from './hooks/api/useSessionApi';
 
 jest.mock('./hooks/api/useSessionApi');
-jest.mock('use-media');
 
 describe('App', () => {
   it('Renders pristine App', () => {

--- a/src/client/components/MyArea/LegendPanel/LegendPanel.tsx
+++ b/src/client/components/MyArea/LegendPanel/LegendPanel.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
-import useMedia from 'use-media';
-import { useWidescreen } from '../../../hooks';
+import { useLandScape, useWidescreen } from '../../../hooks';
 import {
   useFetchPanelFeature,
   useLoadingFeature,
@@ -18,7 +17,7 @@ interface LegendPanelProps {
 export function LegendPanel({ availableHeight }: LegendPanelProps) {
   const isWideScreen = useWidescreen();
   const isNarrowScreen = !isWideScreen;
-  const isLandscape = useMedia('(orientation: landscape)');
+  const isLandscape = useLandScape();
   const [loadingFeature, setLoadingFeature] = useLoadingFeature();
   const prevFilterPanelState = useRef<PanelState | null>(null);
   const resetMyAreaState = useResetMyAreaState();

--- a/src/client/components/MyArea/LegendPanel/panelCycle.ts
+++ b/src/client/components/MyArea/LegendPanel/panelCycle.ts
@@ -1,12 +1,10 @@
 import { useMemo } from 'react';
-import useMedia from 'use-media';
-import { useWidescreen } from '../../../hooks';
+import { useWidescreen, useMediaLayout } from '../../../hooks';
 import { PanelState, usePanelStateCycle } from './PanelComponent';
 
 export function useLegendPanelCycle() {
   const isWideScreen = useWidescreen();
-  const isLandscape = useMedia('(orientation: landscape)');
-
+  const isLandscape = useMediaLayout({ orientation: 'landscape' });
   const panelCycle = useMemo(() => {
     if (isWideScreen) {
       return {

--- a/src/client/components/MyArea/LegendPanel/panelCycle.ts
+++ b/src/client/components/MyArea/LegendPanel/panelCycle.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import { useWidescreen, useMediaLayout } from '../../../hooks';
+import { useWidescreen, useLandScape } from '../../../hooks';
 import { PanelState, usePanelStateCycle } from './PanelComponent';
 
 export function useLegendPanelCycle() {
   const isWideScreen = useWidescreen();
-  const isLandscape = useMediaLayout({ orientation: 'landscape' });
+  const isLandscape = useLandScape();
   const panelCycle = useMemo(() => {
     if (isWideScreen) {
       return {

--- a/src/client/hooks/media.hook.ts
+++ b/src/client/hooks/media.hook.ts
@@ -35,7 +35,7 @@ function queryObjectToString(query: string | MediaQueryObject) {
     .join(' and ');
 }
 
-export function useMediaLayout(query: MediaQueryObject) {
+export function useMediaLayout(query: MediaQueryObject): boolean {
   const queryString = queryObjectToString(query);
   const [matches, setMatches] = useState(() => {
     return !!window.matchMedia(queryString).matches;
@@ -44,10 +44,10 @@ export function useMediaLayout(query: MediaQueryObject) {
   useLayoutEffect(() => {
     const media = window.matchMedia(queryString);
     if (media.matches !== matches) {
-      setMatches(media.matches);
+      setMatches(!!media.matches);
     }
     const listener = () => {
-      setMatches(media.matches);
+      setMatches(!!media.matches);
     };
     media.addListener(listener);
     return () => media.removeListener(listener);

--- a/src/client/hooks/media.hook.ts
+++ b/src/client/hooks/media.hook.ts
@@ -73,3 +73,7 @@ export function usePhoneScreen(): boolean {
 export function useWidescreen(): boolean {
   return useMediaLayout({ minWidth: Breakpoints.wideScreen });
 }
+
+export function useLandScape(): boolean {
+  return useMediaLayout({ orientation: 'landscape' });
+}

--- a/src/client/hooks/media.hook.ts
+++ b/src/client/hooks/media.hook.ts
@@ -1,9 +1,60 @@
 // Helper functions to determine screen size in JS
-import { useMediaLayout } from 'use-media';
+import { useLayoutEffect, useState } from 'react';
 import { Breakpoints } from '../config/app';
+
+export type MediaQueryObject = { [key: string]: string | number | boolean };
 
 const ua = window.navigator.userAgent;
 export const isIE = /MSIE|Trident/.test(ua);
+
+function queryObjectToString(query: string | MediaQueryObject) {
+  if (typeof query === 'string') {
+    return query;
+  }
+
+  return Object.entries(query)
+    .map(([feature, value]) => {
+      const convertedFeature = feature
+        .replace(/[A-Z]/g, (string: string) => `-${string.toLowerCase()}`)
+        .toLowerCase();
+      let convertedValue = value;
+
+      if (typeof convertedValue === 'boolean') {
+        return convertedValue ? convertedFeature : `not ${convertedFeature}`;
+      }
+
+      if (
+        typeof convertedValue === 'number' &&
+        /[height|width]$/.test(convertedFeature)
+      ) {
+        convertedValue = `${convertedValue}px`;
+      }
+
+      return `(${convertedFeature}: ${convertedValue})`;
+    })
+    .join(' and ');
+}
+
+export function useMediaLayout(query: MediaQueryObject) {
+  const queryString = queryObjectToString(query);
+  const [matches, setMatches] = useState(() => {
+    return !!window.matchMedia(queryString).matches;
+  });
+
+  useLayoutEffect(() => {
+    const media = window.matchMedia(queryString);
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    const listener = () => {
+      setMatches(media.matches);
+    };
+    media.addListener(listener);
+    return () => media.removeListener(listener);
+  }, [matches, queryString]);
+
+  return matches;
+}
 
 export function useDesktopScreen(): boolean {
   return useMediaLayout({ minWidth: Breakpoints.tablet + 1 });

--- a/src/client/hooks/useUsabilla.ts
+++ b/src/client/hooks/useUsabilla.ts
@@ -2,6 +2,7 @@ import { IS_AP } from '../../universal/config';
 import { useScript } from './useScript';
 import * as Sentry from '@sentry/react';
 import { useEffect } from 'react';
+import { usePhoneScreen } from './media.hook';
 
 const MAX_WAIT_FOR_USABILA_LIVE_MS = 5000; // 5 seconds
 
@@ -26,10 +27,22 @@ export function waitForUsabillaLiveInWindow() {
 }
 
 export function useUsabilla() {
+  const USABILLA_ID_MOBILE = '9fd5da44aa5b';
+  const USABILLA_ID_DESKTOP = 'e8b4abda34ab';
+  const isPhoneScreen = usePhoneScreen();
   const [isUsabillaLoaded] = useScript('/js/usabilla.js', false, true, IS_AP);
-
   useEffect(() => {
     if (isUsabillaLoaded) {
+      const lightningjs = (window as any).lightningjs;
+      if (lightningjs) {
+        const usabillaID = isPhoneScreen
+          ? USABILLA_ID_MOBILE
+          : USABILLA_ID_DESKTOP;
+        (window as any).usabilla_live = lightningjs.require(
+          'usabilla_live',
+          `https://w.usabilla.com/${usabillaID}.js`
+        );
+      }
       waitForUsabillaLiveInWindow()
         .then(() => {
           (window as any).usabilla_live('data', {
@@ -48,5 +61,5 @@ export function useUsabilla() {
           });
         });
     }
-  }, [isUsabillaLoaded]);
+  }, [isUsabillaLoaded, isPhoneScreen]);
 }

--- a/src/client/hooks/useUsabilla.ts
+++ b/src/client/hooks/useUsabilla.ts
@@ -5,6 +5,8 @@ import { useEffect } from 'react';
 import { usePhoneScreen } from './media.hook';
 
 const MAX_WAIT_FOR_USABILA_LIVE_MS = 5000; // 5 seconds
+const USABILLA_ID_MOBILE = '9fd5da44aa5b';
+const USABILLA_ID_DESKTOP = 'e8b4abda34ab';
 
 export function waitForUsabillaLiveInWindow() {
   let polling: any = null;
@@ -27,8 +29,6 @@ export function waitForUsabillaLiveInWindow() {
 }
 
 export function useUsabilla() {
-  const USABILLA_ID_MOBILE = '9fd5da44aa5b';
-  const USABILLA_ID_DESKTOP = 'e8b4abda34ab';
   const isPhoneScreen = usePhoneScreen();
   const [isUsabillaLoaded] = useScript('/js/usabilla.js', false, true, IS_AP);
   useEffect(() => {

--- a/src/client/pages/Dashboard/Dashboard.test.tsx
+++ b/src/client/pages/Dashboard/Dashboard.test.tsx
@@ -9,8 +9,6 @@ import Dashboard from './Dashboard';
 import { Chapters } from '../../../universal/config/chapter';
 import { AppState } from '../../AppState';
 
-jest.mock('use-media');
-
 // TIPS, NOTIFICATIONS, CASES, BUURT, HOME
 
 const testState: any = {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,2 +1,12 @@
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/extend-expect';
+
+global.matchMedia =
+  global.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener: function () {},
+      removeListener: function () {},
+    };
+  };


### PR DESCRIPTION
- Go for the proposed solution in PR
- Don't use context for mediaqueries.

Checked for an alternative hook/create a hook myself. But we always need a window property to say something about the screen width. So we can't do better than the use-media package. So I suggets to keep using it for now.

With this solution everything works fine