### PR TITLE
Mijn-7439 Actueel same download name as detail page for BBZ-brief

### DIFF
--- a/src/server/services/wpi/content/bbz.ts
+++ b/src/server/services/wpi/content/bbz.ts
@@ -148,10 +148,7 @@ const correctiemail: WpiRequestStatusLabels = {
           document.url
         }`,
         title: 'Bekijk de mail',
-        download: documentDownloadName({
-          datePublished: requestProcess.datePublished,
-          title: 'Bbz-brief',
-        }),
+        download:  document.title.split(/\n/)[0],
       };
     },
   },
@@ -204,10 +201,7 @@ const algemeenBatchDocument: WpiRequestStatusLabels = {
           document.url
         }`,
         title: 'Bekijk de brief voor meer details.',
-        download: documentDownloadName({
-          datePublished: requestProcess.datePublished,
-          title: 'Bbz-brief',
-        }),
+        download:  document.title.split(/\n/)[0],
       };
     },
   },


### PR DESCRIPTION
Voor deze story van download naam verschil Actueel: “2023-12-01-Bbz-brief.pdf”
Detailpagina: “Brief Bbz.pdf”, hadden we bedacht dat de datum eraf moet. Maar hier kom ik van terug na dat ik naar de code keek.
```
 download: documentDownloadName({
          datePublished: requestProcess.datePublished,
          title: 'Bbz-brief',
        }),
```
Die datePublished is namelijk required voor documentDownloadName . En als ik daar een lege string zou meegegeven word de naam ook niet BBZ Brief want hij returnt dit ${format(new Date(item.datePublished), 'yyyy-MM-dd')}-${item.title} dus krijg je alsnog een streepje ervoor. En dit omschrijven heeft implicaties op de andere +-10 keer dat deze functie wordt aangeroepen dus lijkt me ook niet de bedoeling.
Wat wel kan is heel documentDowloadName te skippen en zelfde titel te gebruiken als volgens mij bij de detail page wordt gedaan:

```  
<StatusDetail
      chapter="INKOMEN"
      stateKey="WPI_BBZ"
      pageContent={pageContent}
      maxStepCount={() => -1}
      highlightKey={false}
      statusLabel={() => `Bbz-aanvraag`}
      showStatusLineConnection={!hasDecisionStep} // There is no logical connection between the historic BBZ steps, therefor we do not show the checkmarks as they imply a linear proces.
      documentPathForTracking={(document) =>
        `/downloads/inkomen/bbz/${document.title.split(/\n/)[0]}`
      }
      reverseSteps={hasDecisionStep} // For an unknown business reason, the historic steps of BBZ are shown in reverse.
    />
  );
```

 Dit heb ik nu in de commit gezet, maar weet niet hoe ik het moet dubbel checken want zie lokaal deze brief niet onder actueel staan (alleen onder de detail pagina).

Hebben we geen naming convention voor documenten? Kan  me niet voorstellen dat dit de enige plek is waar dit uiteen loopt.