### PR TITLE
MIJN-8896-FEATURE/Api uitbreiden met aanbiedingen transacties amsapp

### DIFF
--- a/src/client/pages/HLI/HLIStadspas.tsx
+++ b/src/client/pages/HLI/HLIStadspas.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   StadspasBudget,
-  StadspasTransaction,
+  StadspasBudgetTransaction,
 } from '../../../server/services/hli/stadspas-types';
 import { AppRoutes } from '../../../universal/config/routes';
 import {
@@ -100,7 +100,7 @@ export default function HLIStadspas() {
   };
 
   const [transactionsApi, fetchTransactions] = useDataApi<
-    ApiResponse<StadspasTransaction[]>
+    ApiResponse<StadspasBudgetTransaction[]>
   >(requestOptions, apiPristineResult([]));
 
   const isLoadingTransacties = transactionsApi.isLoading;
@@ -198,7 +198,7 @@ export default function HLIStadspas() {
               !!transactionsApi.data.content?.length && (
                 <>
                   <Grid.Cell span="all">
-                    <TableV2<StadspasTransaction>
+                    <TableV2<StadspasBudgetTransaction>
                       className={
                         showMultiBudgetTransactions
                           ? styles.Table_transactions__withBudget

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -415,6 +415,7 @@ export const ExternalConsumerEndpoints = {
   // Privately accessible
   private: {
     STADSPAS_PASSEN: `${BFF_BASE_PATH_PRIVATE}/services/amsapp/stadspas/passen/:${STADSPASSEN_ENDPOINT_PARAMETER}`,
+    STADSPAS_AANBIEDINGEN_TRANSACTIES: `${BFF_BASE_PATH_PRIVATE}/services/amsapp/stadspas/aanbiedingen/transactions/:pasNummer`,
     STADPAS_BUDGET_TRANSACTIES: `${BFF_BASE_PATH_PRIVATE}/services/amsapp/stadspas/budget/transactions/:transactionsKeyEncrypted`,
   },
 };

--- a/src/server/openapi-amsapp.yml
+++ b/src/server/openapi-amsapp.yml
@@ -102,6 +102,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApplicationError'
 
+  /private/api/v1/services/amsapp/stadspas/aanbiedingen/transactions/{transactionsKeyEncrypted}:
+    get:
+      security:
+        - ApiKeyAuth: []
+      description: |
+        Retrieves transaction data data related to the provided transactionKey. \
+        Note: If no transactions are made, an empty array is returned.
+      parameters:
+        - name: transactionsKeyEncrypted
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Returns transactions data
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/StadspasAanbiedingen'
+        '400':
+          description: Returns bad request error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorBadRequest'
+
+        '401':
+          description: Returns unauthorized error (invalid api key)
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorUnauthorized'
+        '500':
+          description: |
+            Returns Application error, any error in code or from failed requests.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ApplicationError'
+
   /private/api/v1/services/amsapp/stadspas/budget/transactions/{transactionsKeyEncrypted}:
     get:
       security:
@@ -189,6 +230,93 @@ components:
         budgetCode:
           type: string
           description: Same as 'StadspasBudget.code'
+
+    StadspasAanbiedingen:
+      type: object
+      properties:
+        number_of_items:
+          type: number
+        'total_items:':
+          type: number
+        totale_aantal:
+          type: number
+        totale_korting:
+          type: number
+        transacties:
+          type: array
+          properties:
+            id:
+              type: number
+            transactiedatum:
+              type: string
+            verleende_korting:
+              type: number
+            annulering:
+              type: boolean
+            geannuleerd:
+              type: boolean
+            pashouder:
+              type: object
+              properties:
+                id:
+                  type: number
+                hoofd_pashouder_id:
+                  type: number
+            leeftijd_pashouder:
+              type: number
+            pas:
+              type: object
+              properties:
+                id:
+                  type: number
+                pasnummer:
+                  type: number
+                pasnummer_volledig:
+                  type: string
+                originele_pas:
+                  type: object
+                  properties:
+                    id:
+                      type: number
+                    pasnummer:
+                      type: number
+                    pasnummer_volledig:
+                      type: string
+            aanbieding:
+              type: object
+              properties:
+                id:
+                  type: number
+                aanbiedingnummer:
+                  type: number
+                publicatienummer:
+                  type: number
+                kortingzin:
+                  type: string
+                omschrijving:
+                  type: string
+                communicatienaam:
+                  type: string
+                pijler:
+                  type: string
+                aanbieder:
+                  type: object
+                  properties:
+                    id:
+                      type: number
+                afbeeldingen:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: number
+                      cdn_url:
+                        type: string
+                      medium:
+                        type: string
+                      size:
+                        type: string
 
     StadspasBudget:
       type: object

--- a/src/server/openapi-amsapp.yml
+++ b/src/server/openapi-amsapp.yml
@@ -244,79 +244,81 @@ components:
           type: number
         transacties:
           type: array
-          properties:
-            id:
-              type: number
-            transactiedatum:
-              type: string
-            verleende_korting:
-              type: number
-            annulering:
-              type: boolean
-            geannuleerd:
-              type: boolean
-            pashouder:
-              type: object
-              properties:
-                id:
-                  type: number
-                hoofd_pashouder_id:
-                  type: number
-            leeftijd_pashouder:
-              type: number
-            pas:
-              type: object
-              properties:
-                id:
-                  type: number
-                pasnummer:
-                  type: number
-                pasnummer_volledig:
-                  type: string
-                originele_pas:
-                  type: object
-                  properties:
-                    id:
-                      type: number
-                    pasnummer:
-                      type: number
-                    pasnummer_volledig:
-                      type: string
-            aanbieding:
-              type: object
-              properties:
-                id:
-                  type: number
-                aanbiedingnummer:
-                  type: number
-                publicatienummer:
-                  type: number
-                kortingzin:
-                  type: string
-                omschrijving:
-                  type: string
-                communicatienaam:
-                  type: string
-                pijler:
-                  type: string
-                aanbieder:
-                  type: object
-                  properties:
-                    id:
-                      type: number
-                afbeeldingen:
-                  type: array
-                  items:
+          items:
+            type: object
+            properties:
+              id:
+                type: number
+              transactiedatum:
+                type: string
+              verleende_korting:
+                type: number
+              annulering:
+                type: boolean
+              geannuleerd:
+                type: boolean
+              pashouder:
+                type: object
+                properties:
+                  id:
+                    type: number
+                  hoofd_pashouder_id:
+                    type: number
+              leeftijd_pashouder:
+                type: number
+              pas:
+                type: object
+                properties:
+                  id:
+                    type: number
+                  pasnummer:
+                    type: number
+                  pasnummer_volledig:
+                    type: string
+                  originele_pas:
                     type: object
                     properties:
                       id:
                         type: number
-                      cdn_url:
+                      pasnummer:
+                        type: number
+                      pasnummer_volledig:
                         type: string
-                      medium:
-                        type: string
-                      size:
-                        type: string
+              aanbieding:
+                type: object
+                properties:
+                  id:
+                    type: number
+                  aanbiedingnummer:
+                    type: number
+                  publicatienummer:
+                    type: number
+                  kortingzin:
+                    type: string
+                  omschrijving:
+                    type: string
+                  communicatienaam:
+                    type: string
+                  pijler:
+                    type: string
+                  aanbieder:
+                    type: object
+                    properties:
+                      id:
+                        type: number
+                  afbeeldingen:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                        cdn_url:
+                          type: string
+                        medium:
+                          type: string
+                        size:
+                          type: string
 
     StadspasBudget:
       type: object

--- a/src/server/services/hli/hli-route-handlers.ts
+++ b/src/server/services/hli/hli-route-handlers.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { AuthProfileAndToken, getAuth } from '../../helpers/app';
 import { fetchDocument } from '../zorgned/zorgned-service';
-import { fetchStadspasTransactions } from './stadspas';
+import { fetchStadspasBudgetTransactionsWithVerify } from './stadspas';
 import { StadspasBudget } from './stadspas-types';
 
 export async function handleFetchTransactionsRequest(
@@ -10,7 +10,7 @@ export async function handleFetchTransactionsRequest(
 ) {
   const authProfileAndToken = await getAuth(req);
 
-  const response = await fetchStadspasTransactions(
+  const response = await fetchStadspasBudgetTransactionsWithVerify(
     res.locals.requestID,
     req.params.transactionsKeyEncrypted,
     req.query.budgetCode as StadspasBudget['code'],

--- a/src/server/services/hli/stadspas-gpass-service.ts
+++ b/src/server/services/hli/stadspas-gpass-service.ts
@@ -22,7 +22,7 @@ import {
   StadspasTransactiesResponseSource,
   StadspasBudgetTransaction,
   StadspasTransactionQueryParams,
-  StadspasAanbiedingenTransaction,
+  StadspasAanbiedingenTransactionResponse,
 } from './stadspas-types';
 
 const NO_PASHOUDER_CONTENT_RESPONSE = apiSuccessResult({
@@ -236,8 +236,7 @@ export async function fetchStadspasAanbiedingenTransactions(
     params: requestParams,
   });
 
-  // RP TODO: Will this be the right type?
-  return requestData<StadspasAanbiedingenTransaction[]>(
+  return requestData<StadspasAanbiedingenTransactionResponse>(
     dataRequestConfig,
     requestID
   );

--- a/src/server/services/hli/stadspas-gpass-service.ts
+++ b/src/server/services/hli/stadspas-gpass-service.ts
@@ -9,10 +9,7 @@ import { getApiConfig, ONE_SECOND_MS } from '../../config';
 import { AuthProfileAndToken } from '../../helpers/app';
 import { requestData } from '../../helpers/source-api-request';
 import { fetchAdministratienummer } from './hli-zorgned-service';
-import {
-  GPASS_API_TOKEN,
-  GPASS_BUDGET_ONLY_FOR_CHILDREN,
-} from './stadspas-config-and-content';
+import { GPASS_API_TOKEN } from './stadspas-config-and-content';
 import {
   Stadspas,
   StadspasBudget,
@@ -23,8 +20,9 @@ import {
   StadspasPasHouderResponse,
   StadspasTransactieSource,
   StadspasTransactiesResponseSource,
-  StadspasTransaction,
+  StadspasBudgetTransaction,
   StadspasTransactionQueryParams,
+  StadspasAanbiedingenTransaction,
 } from './stadspas-types';
 
 const NO_PASHOUDER_CONTENT_RESPONSE = apiSuccessResult({
@@ -205,7 +203,7 @@ function transformGpassTransactionsResponse(
   if (Array.isArray(gpassTransactionsResponseData.transacties)) {
     return gpassTransactionsResponseData.transacties.map(
       (transactie: StadspasTransactieSource) => {
-        const transaction: StadspasTransaction = {
+        const transaction: StadspasBudgetTransaction = {
           id: String(transactie.id),
           title: transactie.budget.aanbieder.naam,
           amount: transactie.bedrag,
@@ -220,6 +218,29 @@ function transformGpassTransactionsResponse(
     );
   }
   return gpassTransactionsResponseData;
+}
+
+export async function fetchStadspasAanbiedingenTransactions(
+  requestID: requestID,
+  administratienummer: string,
+  passNumber: Stadspas['passNumber']
+) {
+  const requestParams: StadspasTransactionQueryParams = {
+    pasnummer: passNumber,
+    sub_transactions: true,
+  };
+
+  const dataRequestConfig = getApiConfig('GPASS', {
+    formatUrl: ({ url }) => `${url}/rest/transacties/v1/aanbiedingen`,
+    headers: getHeaders(administratienummer),
+    params: requestParams,
+  });
+
+  // RP TODO: Will this be the right type?
+  return requestData<StadspasAanbiedingenTransaction[]>(
+    dataRequestConfig,
+    requestID
+  );
 }
 
 export async function fetchStadspasBudgetTransactions(
@@ -244,5 +265,5 @@ export async function fetchStadspasBudgetTransactions(
     params: requestParams,
   });
 
-  return requestData<StadspasTransaction[]>(dataRequestConfig, requestID);
+  return requestData<StadspasBudgetTransaction[]>(dataRequestConfig, requestID);
 }

--- a/src/server/services/hli/stadspas-gpass-service.ts
+++ b/src/server/services/hli/stadspas-gpass-service.ts
@@ -223,10 +223,10 @@ function transformGpassTransactionsResponse(
 export async function fetchStadspasAanbiedingenTransactions(
   requestID: requestID,
   administratienummer: string,
-  passNumber: Stadspas['passNumber']
+  pasnummer: Stadspas['passNumber']
 ) {
   const requestParams: StadspasTransactionQueryParams = {
-    pasnummer: passNumber,
+    pasnummer,
     sub_transactions: true,
   };
 
@@ -245,11 +245,11 @@ export async function fetchStadspasAanbiedingenTransactions(
 export async function fetchStadspasBudgetTransactions(
   requestID: requestID,
   administratienummer: string,
-  passNumber: Stadspas['passNumber'],
+  pasnummer: Stadspas['passNumber'],
   budgetCode?: StadspasBudget['code']
 ) {
   const requestParams: StadspasTransactionQueryParams = {
-    pasnummer: passNumber,
+    pasnummer,
     sub_transactions: true,
   };
 

--- a/src/server/services/hli/stadspas-router-external-consumer.test.ts
+++ b/src/server/services/hli/stadspas-router-external-consumer.test.ts
@@ -236,7 +236,7 @@ describe('hli/router-external-consumer', async () => {
   describe('Budget transactions endpoint', async () => {
     it('Happy path without budgetcode filter', async () => {
       const fetchStadspasTransactionsSpy = vi
-        .spyOn(stadspas, 'fetchStadspasTransactions')
+        .spyOn(stadspas, 'fetchStadspasBudgetTransactionsWithVerify')
         .mockResolvedValueOnce(apiSuccessResult([]));
 
       const reqMock = {
@@ -251,7 +251,7 @@ describe('hli/router-external-consumer', async () => {
 
     it('Happy path with budgetcode filter.', async () => {
       const fetchStadspasTransactionsSpy = vi
-        .spyOn(stadspas, 'fetchStadspasTransactions')
+        .spyOn(stadspas, 'fetchStadspasBudgetTransactionsWithVerify')
         .mockResolvedValueOnce(apiSuccessResult([]));
 
       const reqMock = {

--- a/src/server/services/hli/stadspas-router-external-consumer.test.ts
+++ b/src/server/services/hli/stadspas-router-external-consumer.test.ts
@@ -271,7 +271,7 @@ describe('hli/router-external-consumer', async () => {
 });
 
 // This block is outside of the enveloping describe block above, because
-// the global request and resposne mocks do not play nicely with this test.
+// the global request and response mocks do not play nicely with this test.
 describe('Aanbieding transactions endpoint', async () => {
   function buildStadspasAanbiedingTransactionResponse(): StadspasAanbiedingenTransactionResponse {
     return {
@@ -292,7 +292,7 @@ describe('Aanbieding transactions endpoint', async () => {
     } as unknown as Request<{ transactionsKeyEncrypted: string }>;
     const resMock = ResponseMock.new();
 
-    forTesting.sendAanbiedingenTransactionsResponse(reqMock, resMock);
+    await forTesting.sendAanbiedingenTransactionsResponse(reqMock, resMock);
 
     expect(
       fetchStadspasAanbiedingenTransactionsWithVerifySpy

--- a/src/server/services/hli/stadspas-router-external-consumer.test.ts
+++ b/src/server/services/hli/stadspas-router-external-consumer.test.ts
@@ -9,6 +9,7 @@ import { generateDevSessionCookieValue } from '../../helpers/app.development';
 import { forTesting } from './stadspas-router-external-consumer';
 import { apiSuccessResult } from '../../../universal/helpers/api';
 import * as stadspas from './stadspas';
+import { StadspasAanbiedingenTransactionResponse } from './stadspas-types';
 
 vi.mock('../../../server/helpers/encrypt-decrypt', async (requireActual) => {
   return {
@@ -265,6 +266,36 @@ describe('hli/router-external-consumer', async () => {
 
       expect(fetchStadspasTransactionsSpy).toHaveBeenCalledOnce();
       expect(sendMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Aanbieding transactions endpoint', async () => {
+    function buildStadspasAanbiedingTransactionResponse(): StadspasAanbiedingenTransactionResponse {
+      return {
+        number_of_items: 0,
+        transacties: [],
+      };
+    }
+
+    it('Happy path', async () => {
+      const fetchStadspasAanbiedingenTransactionsWithVerifySpy = vi
+        .spyOn(stadspas, 'fetchStadspasAanbiedingenTransactionsWithVerify')
+        .mockResolvedValueOnce(
+          apiSuccessResult(buildStadspasAanbiedingTransactionResponse())
+        );
+
+      const reqMock = {
+        params: { transactionsKeyEncrypted: TRANSACTIONS_KEY_ENCRYPTED },
+      } as unknown as Request<{ transactionsKeyEncrypted: string }>;
+
+      forTesting.sendAanbiedingenTransactionsResponse(reqMock, resMock);
+
+      expect(
+        fetchStadspasAanbiedingenTransactionsWithVerifySpy
+      ).toHaveBeenCalledWith(
+        resMock.locals.requestID,
+        TRANSACTIONS_KEY_ENCRYPTED
+      );
     });
   });
 });

--- a/src/server/services/hli/stadspas-router-external-consumer.ts
+++ b/src/server/services/hli/stadspas-router-external-consumer.ts
@@ -23,15 +23,8 @@ import {
   fetchStadspasAanbiedingenTransactionsWithVerify,
   fetchStadspasBudgetTransactionsWithVerify,
 } from './stadspas';
-import {
-  fetchStadspasAanbiedingenTransactions,
-  fetchStadspassenByAdministratienummer,
-} from './stadspas-gpass-service';
-import {
-  Stadspas,
-  StadspasAMSAPPFrontend,
-  StadspasBudget,
-} from './stadspas-types';
+import { fetchStadspassenByAdministratienummer } from './stadspas-gpass-service';
+import { StadspasAMSAPPFrontend, StadspasBudget } from './stadspas-types';
 
 const AMSAPP_PROTOCOl = 'amsterdam://';
 const AMSAPP_STADSPAS_DEEP_LINK = `${AMSAPP_PROTOCOl}stadspas`;

--- a/src/server/services/hli/stadspas-router-external-consumer.ts
+++ b/src/server/services/hli/stadspas-router-external-consumer.ts
@@ -18,10 +18,20 @@ import { requestData } from '../../helpers/source-api-request';
 import { apiKeyVerificationHandler } from '../../middleware';
 import { captureException, captureMessage } from '../monitoring';
 import { fetchAdministratienummer } from './hli-zorgned-service';
-import { fetchStadspasTransactions } from './stadspas';
-import { fetchStadspassenByAdministratienummer } from './stadspas-gpass-service';
-import { StadspasAMSAPPFrontend, StadspasBudget } from './stadspas-types';
 import { IS_PRODUCTION } from '../../../universal/config/env';
+import {
+  fetchStadspasAanbiedingenTransactionsWithVerify,
+  fetchStadspasTransactions,
+} from './stadspas';
+import {
+  fetchStadspasAanbiedingenTransactions,
+  fetchStadspassenByAdministratienummer,
+} from './stadspas-gpass-service';
+import {
+  Stadspas,
+  StadspasAMSAPPFrontend,
+  StadspasBudget,
+} from './stadspas-types';
 
 const AMSAPP_PROTOCOl = 'amsterdam://';
 const AMSAPP_STADSPAS_DEEP_LINK = `${AMSAPP_PROTOCOl}stadspas`;
@@ -211,6 +221,24 @@ routerPrivateNetwork.get(
   ExternalConsumerEndpoints.private.STADSPAS_PASSEN,
   apiKeyVerificationHandler,
   sendStadspassenResponse
+);
+
+async function sendAanbiedingenTransactionsResponse(
+  req: Request<{ transactionsKeyEncrypted: string }>,
+  res: Response
+) {
+  const response = await fetchStadspasAanbiedingenTransactionsWithVerify(
+    res.locals.requestID,
+    req.params.transactionsKeyEncrypted
+  );
+
+  sendResponse(res, response);
+}
+
+routerPrivateNetwork.get(
+  ExternalConsumerEndpoints.private.STADSPAS_AANBIEDINGEN_TRANSACTIES,
+  apiKeyVerificationHandler,
+  sendAanbiedingenTransactionsResponse
 );
 
 /** Sends transformed budget transactions.

--- a/src/server/services/hli/stadspas-router-external-consumer.ts
+++ b/src/server/services/hli/stadspas-router-external-consumer.ts
@@ -274,5 +274,6 @@ export const stadspasExternalConsumerRouter = {
 export const forTesting = {
   sendAdministratienummerResponse,
   sendStadspassenResponse,
+  sendAanbiedingenTransactionsResponse,
   sendBudgetTransactionsResponse,
 };

--- a/src/server/services/hli/stadspas-router-external-consumer.ts
+++ b/src/server/services/hli/stadspas-router-external-consumer.ts
@@ -21,7 +21,7 @@ import { fetchAdministratienummer } from './hli-zorgned-service';
 import { IS_PRODUCTION } from '../../../universal/config/env';
 import {
   fetchStadspasAanbiedingenTransactionsWithVerify,
-  fetchStadspasTransactions,
+  fetchStadspasBudgetTransactionsWithVerify,
 } from './stadspas';
 import {
   fetchStadspasAanbiedingenTransactions,
@@ -251,7 +251,7 @@ async function sendBudgetTransactionsResponse(
   req: Request<{ transactionsKeyEncrypted: string }>,
   res: Response
 ) {
-  const response = await fetchStadspasTransactions(
+  const response = await fetchStadspasBudgetTransactionsWithVerify(
     res.locals.requestID,
     req.params.transactionsKeyEncrypted,
     req.query?.budgetCode as StadspasBudget['code']

--- a/src/server/services/hli/stadspas-types.ts
+++ b/src/server/services/hli/stadspas-types.ts
@@ -130,8 +130,13 @@ export interface StadspasTransactionQueryParams {
   budgetCode?: string;
 }
 
-export interface StadspasAanbiedingenTransaction {
-  // RP TODO: Test then implement what is inside the body.
+export interface StadspasAanbiedingenTransactionResponse {
+  number_of_items: number;
+  transacties: AanbiedingTransactie[];
+}
+
+interface AanbiedingTransactie {
+  // RP TODO: What zit hierin???
 }
 
 export interface StadspasBudgetTransaction {

--- a/src/server/services/hli/stadspas-types.ts
+++ b/src/server/services/hli/stadspas-types.ts
@@ -130,8 +130,8 @@ export interface StadspasTransactionQueryParams {
   budgetCode?: string;
 }
 
-// NOTE: The optional properties are not yet tested to be present in a response with transacties of `length > 0`.
-// This is only send raw to the AmsApp at the moment, so knowing the exact shape might not be that important yet.
+// NOTE: Optional properties unconfirmed for non-empty transaction lists.
+// Currently sent raw to AmsApp; exact shape is yet to be determined.
 export interface StadspasAanbiedingenTransactionResponse {
   number_of_items: number;
   'total_items:'?: number;
@@ -140,7 +140,7 @@ export interface StadspasAanbiedingenTransactionResponse {
   transacties: AanbiedingTransactie[];
 }
 
-// NOTE: Taken straight from the documentation, not tested for variations
+// NOTE: Taken straight from the documentation; not tested for variations
 type AanbiedingTransactie = {
   id: number;
   transactiedatum: string;

--- a/src/server/services/hli/stadspas-types.ts
+++ b/src/server/services/hli/stadspas-types.ts
@@ -130,14 +130,65 @@ export interface StadspasTransactionQueryParams {
   budgetCode?: string;
 }
 
+// NOTE: The optional properties are not yet tested to be present in a response with transacties of `length > 0`.
+// This is only send raw to the AmsApp at the moment, so knowing the exact shape might not be that important yet.
 export interface StadspasAanbiedingenTransactionResponse {
   number_of_items: number;
+  'total_items:'?: number;
+  totale_aantal?: number;
+  totale_korting?: number;
   transacties: AanbiedingTransactie[];
 }
 
-interface AanbiedingTransactie {
-  // RP TODO: What zit hierin???
-}
+// NOTE: Taken straight from the documentation, not tested for variations
+type AanbiedingTransactie = {
+  id: number;
+  transactiedatum: string;
+  verleende_korting: number;
+  annulering: boolean;
+  geannuleerd: boolean;
+  pashouder: {
+    id: number;
+    hoofd_pashouder_id: number;
+  };
+  leeftijd_pashouder: number;
+  pas: {
+    id: number;
+    pasnummer: number;
+    pasnummer_volledig: string;
+    originele_pas: {
+      id: number;
+      pasnummer: number;
+      pasnummer_volledig: string;
+    };
+  };
+  aanbieding: {
+    id: number;
+    aanbiedingnummer: number;
+    publicatienummer: number;
+    kortingzin: string;
+    omschrijving: string;
+    communicatienaam: string;
+    pijler: string;
+    aanbieder: {
+      id: number;
+    };
+    afbeeldingen: [
+      {
+        id: number;
+        cdn_url: string;
+        medium: string;
+        size: string;
+      },
+      {
+        id: number;
+        cdn_url: string;
+        medium: string;
+        size: string;
+      },
+    ];
+  };
+};
 
 export interface StadspasBudgetTransaction {
   id: string;

--- a/src/server/services/hli/stadspas-types.ts
+++ b/src/server/services/hli/stadspas-types.ts
@@ -1,3 +1,8 @@
+import {
+  ApiErrorResponse,
+  ApiPostponeResponse,
+  ApiSuccessResponse,
+} from '../../../universal/helpers/api';
 import { LinkProps } from '../../../universal/types/App.types';
 
 export interface StadspasTransactieSource {
@@ -125,7 +130,11 @@ export interface StadspasTransactionQueryParams {
   budgetCode?: string;
 }
 
-export interface StadspasTransaction {
+export interface StadspasAanbiedingenTransaction {
+  // RP TODO: Test then implement what is inside the body.
+}
+
+export interface StadspasBudgetTransaction {
   id: string;
   title: string;
   amount: number;
@@ -135,5 +144,14 @@ export interface StadspasTransaction {
   budget: StadspasBudget['description'];
   budgetCode: StadspasBudget['code'];
 }
+
+export type FetchStadspasTransactionsFn<TContent> = (
+  requestID: requestID,
+  administratienummer: string,
+  passNumber: Stadspas['passNumber'],
+  budgetCode?: StadspasBudget['code']
+) => Promise<
+  ApiPostponeResponse | ApiErrorResponse<null> | ApiSuccessResponse<TContent>
+>;
 
 export type StadspasAdministratieNummer = string;

--- a/src/server/services/hli/stadspas.test.ts
+++ b/src/server/services/hli/stadspas.test.ts
@@ -3,7 +3,7 @@ import * as encryptDecrypt from '../../helpers/encrypt-decrypt';
 import { AuthProfileAndToken } from '../../helpers/app';
 import { fetchAdministratienummer } from './hli-zorgned-service';
 import { fetchStadspassen } from './stadspas-gpass-service';
-import { fetchStadspasTransactions } from './stadspas';
+import { fetchStadspasBudgetTransactionsWithVerify } from './stadspas';
 
 const pashouderResponse = {
   initialen: 'A',
@@ -376,7 +376,7 @@ describe('stadspas services', () => {
       `my-unique-session-id:0363000123-123:123123123`
     );
 
-    const response = await fetchStadspasTransactions(
+    const response = await fetchStadspasBudgetTransactionsWithVerify(
       'abc123',
       transactionsKeyEncrypted,
       undefined,
@@ -407,7 +407,7 @@ describe('stadspas services', () => {
       `another-session-id:0363000123-123:123123123`
     );
 
-    const response = await fetchStadspasTransactions(
+    const response = await fetchStadspasBudgetTransactionsWithVerify(
       'xyz098',
       transactionsKeyEncrypted,
       undefined,
@@ -425,7 +425,7 @@ describe('stadspas services', () => {
   });
 
   test('stadspas transacties bad encrypted key', async () => {
-    const response = await fetchStadspasTransactions(
+    const response = await fetchStadspasBudgetTransactionsWithVerify(
       'xyz098',
       'FOO.BAR.XYZ',
       undefined,

--- a/src/server/services/hli/stadspas.ts
+++ b/src/server/services/hli/stadspas.ts
@@ -64,9 +64,10 @@ export async function fetchStadspas(
   return stadspasResponse;
 }
 
-export const fetchStadspasTransactions = createTransactionFetchFn<
-  StadspasBudgetTransaction[]
->(fetchStadspasBudgetTransactions);
+export const fetchStadspasBudgetTransactionsWithVerify =
+  createTransactionFetchFn<StadspasBudgetTransaction[]>(
+    fetchStadspasBudgetTransactions
+  );
 
 // RP TODO: Will this be the right type?
 export const fetchStadspasAanbiedingenTransactionsWithVerify =

--- a/src/server/services/hli/stadspas.ts
+++ b/src/server/services/hli/stadspas.ts
@@ -18,7 +18,7 @@ import {
   StadspasBudget,
   StadspasFrontend,
   StadspasBudgetTransaction,
-  StadspasAanbiedingenTransaction,
+  StadspasAanbiedingenTransactionResponse,
   FetchStadspasTransactionsFn,
 } from './stadspas-types';
 
@@ -69,9 +69,8 @@ export const fetchStadspasBudgetTransactionsWithVerify =
     fetchStadspasBudgetTransactions
   );
 
-// RP TODO: Will this be the right type?
 export const fetchStadspasAanbiedingenTransactionsWithVerify =
-  createTransactionFetchFn<StadspasAanbiedingenTransaction[]>(
+  createTransactionFetchFn<StadspasAanbiedingenTransactionResponse>(
     fetchStadspasAanbiedingenTransactions
   );
 


### PR DESCRIPTION
- Added endpoints `sendAanbiedingenTransactionsResponse` in `stadspas-router-external-consumer`.
- Refactored budget transaction endpoint for reuse of the validation step.
    - This is done by making a function that creates new functions that does some validation before sending the next request.
- Added unit tests.