### PR TITLE
MIJN-9105-BUG-amsapp-word-naar-de-verkeerde-url-geredirect-bij-het-aanroepen-van-administratienummer

### DIFF
--- a/src/server/helpers/auth.ts
+++ b/src/server/helpers/auth.ts
@@ -18,8 +18,7 @@ export function getReturnToUrl(queryParams?: ParsedQs) {
         ExternalConsumerEndpoints.public.STADSPAS_ADMINISTRATIENUMMER,
         {
           token: queryParams['amsapp-session-token'] as string,
-        },
-        BFF_API_BASE_URL.replace(BFF_BASE_PATH, '') // The STADSPAS_ADMINISTRATIENUMMER path already has /api/v1 in it
+        }
       );
     default:
     case RETURNTO_MAMS_LANDING:


### PR DESCRIPTION
- Lijn code verwijdert die '/api/v1' verwijdert zonder dat dat moet gebeuren.