### PR TITLE
MIJN-9208-FEATURE-url-word-meegestuurd-met-api-v1-endpoint

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -13,7 +13,6 @@ MA_FRONTEND_URL=http://localhost:3000
 
 # The last commit deployed in the build
 MA_GIT_SHA
-MA_GIT_CURRENT_BRANCH=testen
 
 # The server environment Development Test Acceptance Production
 MA_OTAP_ENV=development

--- a/.env.local.template
+++ b/.env.local.template
@@ -13,6 +13,7 @@ MA_FRONTEND_URL=http://localhost:3000
 
 # The last commit deployed in the build
 MA_GIT_SHA
+MA_GIT_CURRENT_BRANCH=testen
 
 # The server environment Development Test Acceptance Production
 MA_OTAP_ENV=development

--- a/src/server/routing/router-public.ts
+++ b/src/server/routing/router-public.ts
@@ -29,6 +29,7 @@ import {
   QueryParamsMaintenanceNotifications,
   fetchMaintenanceNotificationsActual,
 } from '../services/cms-maintenance-notifications';
+import { getFromEnv } from '../helpers/env';
 
 export const router = express.Router();
 
@@ -200,14 +201,19 @@ export async function zaakStatusHandler(
   return res.redirect(loginRouteWithReturnTo);
 }
 
+const branchName = getFromEnv('MA_GIT_CURRENT_BRANCH', true);
+
 router.get(
   [BffEndpoints.ROOT, BffEndpoints.STATUS_HEALTH],
-  (req: Request, res: Response, next: NextFunction) => {
+  (_req: Request, res: Response) => {
     return res.json({
       status: 'OK',
       otapEnv: OTAP_ENV,
       release: RELEASE_VERSION,
       gitSha: process.env.MA_GIT_SHA ?? '-1',
+      gitCommitHistoryUrl: branchName
+        ? `https://github.com/Amsterdam/mijn-amsterdam-frontend/commits/${branchName}/`
+        : 'Error: No branchname specified in .env.local please check MA_GIT_CURRENT_BRANCH',
       buildId: process.env.MA_BUILD_ID ?? '-1',
     });
   }

--- a/src/server/routing/router-public.ts
+++ b/src/server/routing/router-public.ts
@@ -201,7 +201,7 @@ export async function zaakStatusHandler(
   return res.redirect(loginRouteWithReturnTo);
 }
 
-const branchName = getFromEnv('MA_GIT_CURRENT_BRANCH', true);
+const gitSHA = getFromEnv('MA_GIT_SHA', true) ?? -1;
 
 router.get(
   [BffEndpoints.ROOT, BffEndpoints.STATUS_HEALTH],
@@ -210,10 +210,8 @@ router.get(
       status: 'OK',
       otapEnv: OTAP_ENV,
       release: RELEASE_VERSION,
-      gitSha: process.env.MA_GIT_SHA ?? '-1',
-      gitCommitHistoryUrl: branchName
-        ? `https://github.com/Amsterdam/mijn-amsterdam-frontend/commits/${branchName}/`
-        : 'Error: No branchname specified in .env.local please check MA_GIT_CURRENT_BRANCH',
+      gitSha: gitSHA,
+      gitShaUrl: `https://github.com/Amsterdam/mijn-amsterdam-frontend/commit/${gitSHA}`,
       buildId: process.env.MA_BUILD_ID ?? '-1',
     });
   }

--- a/src/server/routing/router-public.ts
+++ b/src/server/routing/router-public.ts
@@ -201,7 +201,7 @@ export async function zaakStatusHandler(
   return res.redirect(loginRouteWithReturnTo);
 }
 
-const gitSHA = getFromEnv('MA_GIT_SHA', true) ?? -1;
+const gitSHA = getFromEnv('MA_GIT_SHA', false) ?? -1;
 
 router.get(
   [BffEndpoints.ROOT, BffEndpoints.STATUS_HEALTH],


### PR DESCRIPTION
Variablen url toegevoegd die zich aanpast aan der hand van op welke omgeving die staat. Default voor local staat op testen in de .env.template anders krijg je een error string waar de url hoort te zitten.

Samen met https://dev.azure.com/CloudCompetenceCenter/MijnAmsterdam/_git/mijn-amsterdam-infra/pullrequest/35598 voor de branch naam.