### PR TITLE
MIJN-9860-Bug - Fix paths

### DIFF
--- a/src/server/services/afis/afis-business-partner.test.ts
+++ b/src/server/services/afis/afis-business-partner.test.ts
@@ -131,6 +131,7 @@ describe('Afis Business Partner services', () => {
           "email": "xxmail@arjanappel.nl",
           "fullName": "Taxon Expeditions BV",
           "id": 430844,
+          "phone": "+31622030313",
         },
         "status": "OK",
       }

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -10,7 +10,7 @@ const ENV_FILE = '.env.local.template';
 const envConfig = dotenv.config({ path: ENV_FILE });
 dotenvExpand.expand(envConfig);
 
-vi.mock('./server/helpers/env.ts', async (importOriginal) => {
+vi.mock('../server/helpers/env.ts', async (importOriginal) => {
   const envModule: object = await importOriginal();
   return {
     ...envModule,
@@ -19,21 +19,21 @@ vi.mock('./server/helpers/env.ts', async (importOriginal) => {
   };
 });
 
-vi.mock('./universal/config/feature-toggles.ts', async (importOriginal) => {
+vi.mock('../universal/config/feature-toggles.ts', async (importOriginal) => {
   const featureToggleModule: {
     FeatureToggle: Record<string, string>;
   } = await importOriginal();
 
-  let featureTogglesOn = Object.entries(featureToggleModule.FeatureToggle).map(
-    ([keyName]) => {
-      return [keyName, true];
-    }
-  );
-  featureTogglesOn = Object.fromEntries(featureTogglesOn);
+  const featureTogglesOn = Object.entries(
+    featureToggleModule.FeatureToggle
+  ).map(([keyName]) => {
+    return [keyName, true];
+  });
+  const FeatureToggle = Object.fromEntries(featureTogglesOn);
 
   return {
     ...featureToggleModule,
-    featureTogglesOn,
+    FeatureToggle,
   };
 });
 


### PR DESCRIPTION
Bij het zetten van een toggle naar false bleek dat deze mock niet goed werkte.

1. doordat de module niet goed gemocked was
2. doordat de mock paden niet meer klopten (modules met statische paden mocken is foutgevoelig)