### PR TITLE
MIJN-9740-BUG/themapagina-parkeren-toont-iets-andere-vergunning-naam-dan-op-themapagina-vergunningen-en-ontheffingen

### DIFF
--- a/src/client/pages/Parkeren/ParkerenList.test.tsx
+++ b/src/client/pages/Parkeren/ParkerenList.test.tsx
@@ -102,7 +102,6 @@ describe('ParkerenList', () => {
 
   it('should render the component and show the correct title', () => {
     render(<Component />);
-    const allText = screen.getAllByText(ThemaTitles.PARKEREN);
     expect(screen.getAllByText(ThemaTitles.PARKEREN)[0]).toBeInTheDocument();
   });
 

--- a/src/client/pages/Parkeren/__snapshots__/Parkeren.test.tsx.snap
+++ b/src/client/pages/Parkeren/__snapshots__/Parkeren.test.tsx.snap
@@ -214,17 +214,17 @@ exports[`Parkeren > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    Z/24/2233516
-                  </td>
-                  <td
-                    class="ams-table__cell"
-                  >
                     <a
                       class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
                       href="/parkeren/gpp/Z-24-2233516"
                     >
-                      Vergunning 1
+                      Z/24/2233516
                     </a>
+                  </td>
+                  <td
+                    class="ams-table__cell"
+                  >
+                    Vergunning 1
                   </td>
                   <td
                     class="ams-table__cell"
@@ -238,17 +238,17 @@ exports[`Parkeren > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    Z/24/2233516
-                  </td>
-                  <td
-                    class="ams-table__cell"
-                  >
                     <a
                       class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
                       href="/parkeren/gpp/Z-24-2233516"
                     >
-                      Vergunning 2
+                      Z/24/2233516
                     </a>
+                  </td>
+                  <td
+                    class="ams-table__cell"
+                  >
+                    Vergunning 2
                   </td>
                   <td
                     class="ams-table__cell"

--- a/src/client/pages/Parkeren/__snapshots__/ParkerenList.test.tsx.snap
+++ b/src/client/pages/Parkeren/__snapshots__/ParkerenList.test.tsx.snap
@@ -111,17 +111,17 @@ exports[`ParkerenList > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    Z/24/2233516
-                  </td>
-                  <td
-                    class="ams-table__cell"
-                  >
                     <a
                       class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
                       href="/parkeren/gpp/Z-24-2233516"
                     >
-                      Vergunning 1
+                      Z/24/2233516
                     </a>
+                  </td>
+                  <td
+                    class="ams-table__cell"
+                  >
+                    Vergunning 1
                   </td>
                   <td
                     class="ams-table__cell"
@@ -135,17 +135,17 @@ exports[`ParkerenList > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    Z/24/2233516
-                  </td>
-                  <td
-                    class="ams-table__cell"
-                  >
                     <a
                       class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
                       href="/parkeren/gpp/Z-24-2233516"
                     >
-                      Vergunning 2
+                      Z/24/2233516
                     </a>
+                  </td>
+                  <td
+                    class="ams-table__cell"
+                  >
+                    Vergunning 2
                   </td>
                   <td
                     class="ams-table__cell"

--- a/src/client/pages/Parkeren/useParkerenData.hook.tsx
+++ b/src/client/pages/Parkeren/useParkerenData.hook.tsx
@@ -32,7 +32,8 @@ function getVergunningenFromThemaVergunningen(
           ...vergunning.link,
           to: vergunning.link.to.replace('vergunningen', 'parkeren'),
         },
-      }))
+      })),
+    'identifier'
   );
 }
 

--- a/src/client/pages/Vergunningen/Vergunningen.tsx
+++ b/src/client/pages/Vergunningen/Vergunningen.tsx
@@ -15,6 +15,7 @@ import {
   SectionCollapsible,
   Table,
   ThemaIcon,
+  addTitleLinkComponent,
 } from '../../components';
 import { OverviewPage } from '../../components/Page/Page';
 import { ThemaTitles } from '../../config/thema';
@@ -36,7 +37,8 @@ export const DISPLAY_PROPS_HISTORY = {
 export default function Vergunningen() {
   const { VERGUNNINGEN } = useAppStateGetter();
 
-  const vergunningen: Vergunning[] = useVergunningenTransformed(VERGUNNINGEN);
+  let vergunningen: Vergunning[] = useVergunningenTransformed(VERGUNNINGEN);
+  vergunningen = addTitleLinkComponent(vergunningen, 'identifier');
 
   const vergunningenPrevious = useMemo(() => {
     return vergunningen

--- a/src/client/pages/Vergunningen/useVergunningenTransformed.hook.ts
+++ b/src/client/pages/Vergunningen/useVergunningenTransformed.hook.ts
@@ -31,9 +31,10 @@ export function useVergunningenTransformed(
         title:
           typeof transformer === 'function' ? transformer(item) : item.title,
         dateRequest: defaultDateFormat(item.dateRequest),
+        identifier: item.identifier,
       };
     });
-    return addTitleLinkComponent(items, 'identifier');
+    return items;
   }, [VERGUNNINGEN.content]);
 
   return vergunningen;

--- a/src/client/pages/Vergunningen/useVergunningenTransformed.hook.ts
+++ b/src/client/pages/Vergunningen/useVergunningenTransformed.hook.ts
@@ -31,7 +31,6 @@ export function useVergunningenTransformed(
         title:
           typeof transformer === 'function' ? transformer(item) : item.title,
         dateRequest: defaultDateFormat(item.dateRequest),
-        identifier: item.identifier,
       };
     });
     return items;


### PR DESCRIPTION
Fix voor parkeren links op de themepagina die onder het verkeerde kopje stonden.
Deze staan nu verwerkt in het kenmerk (lijkt ongeveer op Z/123/1234).