### PR TITLE
MIJN-9753-BUG/parkeerontheffingen-blauwe-zone-bedrijven-wordt-niet-getoond-onder-thema-parkeren-bij-inlog-met-eh

### DIFF
--- a/src/client/pages/Parkeren/__snapshots__/Parkeren.test.tsx.snap
+++ b/src/client/pages/Parkeren/__snapshots__/Parkeren.test.tsx.snap
@@ -214,17 +214,17 @@ exports[`Parkeren > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    <a
-                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
-                      href="/parkeren/gpp/Z-24-2233516"
-                    >
-                      Z/24/2233516
-                    </a>
+                    Z/24/2233516
                   </td>
                   <td
                     class="ams-table__cell"
                   >
-                    Vergunning 1
+                    <a
+                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
+                      href="/parkeren/gpp/Z-24-2233516"
+                    >
+                      Vergunning 1
+                    </a>
                   </td>
                   <td
                     class="ams-table__cell"
@@ -238,17 +238,17 @@ exports[`Parkeren > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    <a
-                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
-                      href="/parkeren/gpp/Z-24-2233516"
-                    >
-                      Z/24/2233516
-                    </a>
+                    Z/24/2233516
                   </td>
                   <td
                     class="ams-table__cell"
                   >
-                    Vergunning 2
+                    <a
+                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
+                      href="/parkeren/gpp/Z-24-2233516"
+                    >
+                      Vergunning 2
+                    </a>
                   </td>
                   <td
                     class="ams-table__cell"

--- a/src/client/pages/Parkeren/__snapshots__/ParkerenList.test.tsx.snap
+++ b/src/client/pages/Parkeren/__snapshots__/ParkerenList.test.tsx.snap
@@ -111,17 +111,17 @@ exports[`ParkerenList > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    <a
-                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
-                      href="/parkeren/gpp/Z-24-2233516"
-                    >
-                      Z/24/2233516
-                    </a>
+                    Z/24/2233516
                   </td>
                   <td
                     class="ams-table__cell"
                   >
-                    Vergunning 1
+                    <a
+                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
+                      href="/parkeren/gpp/Z-24-2233516"
+                    >
+                      Vergunning 1
+                    </a>
                   </td>
                   <td
                     class="ams-table__cell"
@@ -135,17 +135,17 @@ exports[`ParkerenList > should display the list of parkeervergunningen 1`] = `
                   <td
                     class="ams-table__cell"
                   >
-                    <a
-                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
-                      href="/parkeren/gpp/Z-24-2233516"
-                    >
-                      Z/24/2233516
-                    </a>
+                    Z/24/2233516
                   </td>
                   <td
                     class="ams-table__cell"
                   >
-                    Vergunning 2
+                    <a
+                      class="ams-link ams-link--standalone _MaRouterLink__no-underline-fat_aa758a"
+                      href="/parkeren/gpp/Z-24-2233516"
+                    >
+                      Vergunning 2
+                    </a>
                   </td>
                   <td
                     class="ams-table__cell"

--- a/src/client/pages/Parkeren/useParkerenData.hook.tsx
+++ b/src/client/pages/Parkeren/useParkerenData.hook.tsx
@@ -12,6 +12,7 @@ export const PARKEER_CASE_TYPES: Set<DecosCaseType> = new Set([
   CaseType.GPK,
   CaseType.GPP,
   CaseType.BZP,
+  CaseType.BZB,
   CaseType.EigenParkeerplaats,
   CaseType.EigenParkeerplaatsOpheffen,
   CaseType.TouringcarDagontheffing,
@@ -21,18 +22,19 @@ export const PARKEER_CASE_TYPES: Set<DecosCaseType> = new Set([
 function getVergunningenFromThemaVergunningen(
   content: VergunningFrontendV2[] | Vergunning[] | null
 ) {
+  const vergunningen = (content ?? [])
+    .filter((vergunning) => {
+      return PARKEER_CASE_TYPES.has(vergunning.caseType as DecosCaseType);
+    })
+    .map((vergunning) => ({
+      ...vergunning,
+      link: {
+        ...vergunning.link,
+        to: vergunning.link.to.replace('vergunningen', 'parkeren'),
+      },
+    }));
   return addLinkElementToProperty<VergunningFrontendV2 | Vergunning>(
-    (content ?? [])
-      .filter((vergunning) =>
-        PARKEER_CASE_TYPES.has(vergunning.caseType as DecosCaseType)
-      )
-      .map((vergunning) => ({
-        ...vergunning,
-        link: {
-          ...vergunning.link,
-          to: vergunning.link.to.replace('vergunningen', 'parkeren'),
-        },
-      }))
+    vergunningen
   );
 }
 

--- a/src/universal/config/feature-toggles.ts
+++ b/src/universal/config/feature-toggles.ts
@@ -107,8 +107,8 @@ export const FeatureToggle = {
   // Vergunningen V1 (met koppel api)
   vergunningenActive: true,
   // Vergunningen V2 met BFF integratie
-  vergunningenV2Active: IS_DEVELOPMENT, // TODO: Enable when working on MIJN-8914
-  decosServiceActive: IS_DEVELOPMENT, // TODO: Enable when working on MIJN-8914
+  vergunningenV2Active: false, // TODO: Enable when working on MIJN-8914
+  decosServiceActive: false, // TODO: Enable when working on MIJN-8914
 
   // WIOR Kaar data
   wiorDatasetActive: true,


### PR DESCRIPTION
Ik heb de featuretoggle hier uitgezet want steeds moet ik dat weer doen als ik van branches switch of vergelijk met acc.
Voorderest na wat zoeken, hoefde ik alleen een casetype toe tevoegen. Hierdoor verschijnen ze wel ook bij Digid lokaal maar het lijkt me raar als de API KVK data teruggeeft aan een digid account. Dus is dat denk ik geen probleem in productie