### PR TITLE
MIJN-10029-BUG/erfpacht-v-2-status-checken-self-signed-certificate-melding-fixen

### DIFF
--- a/src/server/config/source-api.ts
+++ b/src/server/config/source-api.ts
@@ -110,7 +110,7 @@ const postponeFetchContactmomenten =
     ? contactmomentenFeatureToggle === 'false'
     : !FeatureToggle.contactmomentenActive;
 
-const BFFserverClientAgent = {
+const httpsAgentConfigBFF = {
   cert: getCert('BFF_SERVER_CLIENT_CERT'),
   key: getCert('BFF_SERVER_CLIENT_KEY'),
 };
@@ -128,7 +128,7 @@ export const ApiConfig: ApiDataRequestConfig = {
       'Content-type': 'application/json; charset=utf-8',
       'X-Mams-Api-User': 'JZD',
     },
-    httpsAgent: new https.Agent(BFFserverClientAgent),
+    httpsAgent: new https.Agent(httpsAgentConfigBFF),
   },
   ZORGNED_AV: {
     method: 'post',
@@ -192,7 +192,7 @@ export const ApiConfig: ApiDataRequestConfig = {
     url: `${getFromEnv('BFF_CLEOPATRA_API_ENDPOINT')}`,
     postponeFetch: !FeatureToggle.cleopatraApiActive,
     method: 'POST',
-    httpsAgent: new https.Agent(BFFserverClientAgent),
+    httpsAgent: new https.Agent(httpsAgentConfigBFF),
   },
   DECOS_API: {
     url: `${getFromEnv('BFF_DECOS_API_BASE_URL')}`,
@@ -255,7 +255,7 @@ export const ApiConfig: ApiDataRequestConfig = {
   ERFPACHTv2: {
     url: getFromEnv('BFF_ERFPACHT_API_URL'),
     passthroughOIDCToken: true,
-    httpsAgent: new https.Agent(BFFserverClientAgent),
+    httpsAgent: new https.Agent(httpsAgentConfigBFF),
     postponeFetch:
       !FeatureToggle.erfpachtV2EndpointActive ||
       !getFromEnv('BFF_ERFPACHT_API_URL'),

--- a/src/server/config/source-api.ts
+++ b/src/server/config/source-api.ts
@@ -257,7 +257,8 @@ export const ApiConfig: ApiDataRequestConfig = {
     url: getFromEnv('BFF_ERFPACHT_API_URL'),
     passthroughOIDCToken: true,
     httpsAgent: new https.Agent({
-      ca: IS_TAP ? getCert('BFF_SERVER_CLIENT_CERT') : [],
+      cert: IS_TAP ? getCert('BFF_ZORGNED_AV_CERT') : '',
+      key: IS_TAP ? getCert('BFF_ZORGNED_AV_KEY') : '',
     }),
     postponeFetch:
       !FeatureToggle.erfpachtV2EndpointActive ||

--- a/src/server/config/source-api.ts
+++ b/src/server/config/source-api.ts
@@ -110,6 +110,11 @@ const postponeFetchContactmomenten =
     ? contactmomentenFeatureToggle === 'false'
     : !FeatureToggle.contactmomentenActive;
 
+const BFFserverClientAgent = {
+  cert: getCert('BFF_SERVER_CLIENT_CERT'),
+  key: getCert('BFF_SERVER_CLIENT_KEY'),
+};
+
 export const ApiConfig: ApiDataRequestConfig = {
   AFIS: {
     postponeFetch: postponeFetchAfis,
@@ -123,10 +128,7 @@ export const ApiConfig: ApiDataRequestConfig = {
       'Content-type': 'application/json; charset=utf-8',
       'X-Mams-Api-User': 'JZD',
     },
-    httpsAgent: new https.Agent({
-      cert: getCert('BFF_SERVER_CLIENT_CERT'),
-      key: getCert('BFF_SERVER_CLIENT_KEY'),
-    }),
+    httpsAgent: new https.Agent(BFFserverClientAgent),
   },
   ZORGNED_AV: {
     method: 'post',
@@ -190,10 +192,7 @@ export const ApiConfig: ApiDataRequestConfig = {
     url: `${getFromEnv('BFF_CLEOPATRA_API_ENDPOINT')}`,
     postponeFetch: !FeatureToggle.cleopatraApiActive,
     method: 'POST',
-    httpsAgent: new https.Agent({
-      cert: getCert('BFF_SERVER_CLIENT_CERT'),
-      key: getCert('BFF_SERVER_CLIENT_KEY'),
-    }),
+    httpsAgent: new https.Agent(BFFserverClientAgent),
   },
   DECOS_API: {
     url: `${getFromEnv('BFF_DECOS_API_BASE_URL')}`,
@@ -256,10 +255,7 @@ export const ApiConfig: ApiDataRequestConfig = {
   ERFPACHTv2: {
     url: getFromEnv('BFF_ERFPACHT_API_URL'),
     passthroughOIDCToken: true,
-    httpsAgent: new https.Agent({
-      cert: IS_TAP ? getCert('BFF_SERVER_CLIENT_CERT') : '',
-      key: IS_TAP ? getCert('BFF_SERVER_CLIENT_KEY') : '',
-    }),
+    httpsAgent: new https.Agent(BFFserverClientAgent),
     postponeFetch:
       !FeatureToggle.erfpachtV2EndpointActive ||
       !getFromEnv('BFF_ERFPACHT_API_URL'),

--- a/src/server/config/source-api.ts
+++ b/src/server/config/source-api.ts
@@ -257,8 +257,8 @@ export const ApiConfig: ApiDataRequestConfig = {
     url: getFromEnv('BFF_ERFPACHT_API_URL'),
     passthroughOIDCToken: true,
     httpsAgent: new https.Agent({
-      cert: IS_TAP ? getCert('BFF_ZORGNED_AV_CERT') : '',
-      key: IS_TAP ? getCert('BFF_ZORGNED_AV_KEY') : '',
+      cert: IS_TAP ? getCert('BFF_SERVER_CLIENT_CERT') : '',
+      key: IS_TAP ? getCert('BFF_SERVER_CLIENT_KEY') : '',
     }),
     postponeFetch:
       !FeatureToggle.erfpachtV2EndpointActive ||


### PR DESCRIPTION
Werkt nog niet maar nu staat het in iedergeval wel klaar om het verder te testen. Dit geeft geen cert error meer