### PR TITLE
MIJN-10042-Bug - Do not present download link for old facturen

### DIFF
--- a/mocks/fixtures/afis/openstaande-facturen.json
+++ b/mocks/fixtures/afis/openstaande-facturen.json
@@ -101,8 +101,8 @@
             "NetDueDate": "2023-03-23T00:00:00",
             "NetPaymentAmount": "-900.98",
             "AmountInBalanceTransacCrcy": "1000.00",
-            "DocumentReferenceID": "5555555-D",
-            "AccountingDocument": "5555555-D",
+            "DocumentReferenceID": "1231231230",
+            "AccountingDocument": "1231231230",
             "Paylink": "http://localhost:3100/mocks-api/afis/paylink"
           }
         }

--- a/src/universal/config/feature-toggles.ts
+++ b/src/universal/config/feature-toggles.ts
@@ -8,6 +8,8 @@ export const FeatureToggle = {
   // We don't filter out the undownloadable facturen for testing purposes.
   // We want to be able to test immediately and not wait until the evening.
   afisFilterOutUndownloadableFacturenActive: IS_OT || IS_PRODUCTION,
+  // See also MIJN-10042: Bug where migrated documents "$year < 2025" do not have PDF downloads available.
+  afisMigratedFacturenDownloadActive: !IS_PRODUCTION,
 
   // AVG (Smile)
   avgActive: true,


### PR DESCRIPTION

<img width="1138" alt="Screenshot 2025-02-14 at 17 37 20" src="https://github.com/user-attachments/assets/cb9dd922-1aba-4c91-8093-bb6454faa86e" />
Test door `FeatureToggle.afisMigratedFacturenDownloadActive = false` te zetten. Je ziet dan dat facturen met nummers korter dan 10 cijfers geen downloadlink hebben.