### PR TITLE
MIJN-10133-BUG/afval-maak-een-afspraak-button-niet-meer-zichtbaar-zonder-eroverheen-te-hoveren

### DIFF
--- a/src/client/pages/GarbageInformation/GarbageInformation.tsx
+++ b/src/client/pages/GarbageInformation/GarbageInformation.tsx
@@ -363,7 +363,6 @@ export default function GarbageInformation() {
             )}
             <p>
               <Button
-                className={styles.ContactLink}
                 onClick={() =>
                   (window.location.href = ExternalUrls.AFVAL_MELDING_FORMULIER)
                 }

--- a/src/client/pages/GarbageInformation/GarbageInformation.tsx
+++ b/src/client/pages/GarbageInformation/GarbageInformation.tsx
@@ -75,7 +75,7 @@ function InstructionCTA({ fraction }: InstructionCTAProps) {
   if (fraction.instructieCTA) {
     return (
       <>
-        <p>
+        <p className="ams-paragraph">
           <ButtonLink
             href={fraction.instructieCTA.to}
             external={!fraction.instructieCTA.to.startsWith(AppRoutes.BUURT)}

--- a/src/client/pages/GarbageInformation/__snapshots__/GarbageInformation.test.tsx.snap
+++ b/src/client/pages/GarbageInformation/__snapshots__/GarbageInformation.test.tsx.snap
@@ -576,7 +576,7 @@ exports[`<GarbageInformation /> > Does not show warning concercing bedrijfsafval
       </div>
       <p>
         <button
-          class="_Button_c3ab45 _Button__secondary_c3ab45 _ContactLink_3a64c8"
+          class="_Button_c3ab45 _Button__secondary_c3ab45"
         >
           Klopt de informatie niet? Geef het door
         </button>
@@ -1255,7 +1255,7 @@ exports[`<GarbageInformation /> > Does not show warning concercing woonfunctie 1
       </div>
       <p>
         <button
-          class="_Button_c3ab45 _Button__secondary_c3ab45 _ContactLink_3a64c8"
+          class="_Button_c3ab45 _Button__secondary_c3ab45"
         >
           Klopt de informatie niet? Geef het door
         </button>
@@ -1950,7 +1950,7 @@ exports[`<GarbageInformation /> > Matches the Full Page snapshot 1`] = `
       </div>
       <p>
         <button
-          class="_Button_c3ab45 _Button__secondary_c3ab45 _ContactLink_3a64c8"
+          class="_Button_c3ab45 _Button__secondary_c3ab45"
         >
           Klopt de informatie niet? Geef het door
         </button>


### PR DESCRIPTION
De button bij afval is op sommige browser niet zichtbaar (zoals firefox) dit komt omdat er een not:p(.ams-paragraph) selector de text kleur veranderd. Door .ams-paragraph toe te voegen gebeurd dit niet meer.

Die andere verwijderde class verwees naar helemaal niks, deze bestond immer niet in het bestand of een ander bestand. Dus deze heb ik weggehaald