### PR TITLE
MIJN-13176-BUG: Remove imports universal to server

### DIFF
--- a/src/scripts/generate-user-data-overview.ts
+++ b/src/scripts/generate-user-data-overview.ts
@@ -37,7 +37,7 @@ import * as XLSX from 'xlsx';
 import * as fs from 'node:fs';
 import { defaultDateFormat } from '../universal/helpers/date.ts';
 import { getFullAddress } from '../universal/helpers/brp.ts';
-import { testAccountDataDigid } from '../universal/config/auth.development.ts';
+import { testAccountDataDigid } from '../server/auth/auth-development.ts';
 
 import { differenceInYears, parseISO } from 'date-fns';
 

--- a/src/server/auth/auth-development.ts
+++ b/src/server/auth/auth-development.ts
@@ -1,5 +1,5 @@
-import { IS_PRODUCTION } from './env.ts';
-import { getFromEnv } from '../../server/helpers/env.ts';
+import { IS_PRODUCTION } from '../../universal/config/env.ts';
+import { getFromEnv } from '../helpers/env.ts';
 
 export const DEV_USER_ID_DEFAULT =
   getFromEnv('MA_PROFILE_DEV_ID', false) || 'I.M Mokum';

--- a/src/server/routing/app-router-development.ts
+++ b/src/server/routing/app-router-development.ts
@@ -12,11 +12,6 @@ import {
   sendBadRequest,
   sendUnauthorized,
 } from './route-helpers.ts';
-import type { TestUserData } from '../../universal/config/auth.development.ts';
-import {
-  testAccountDataDigid,
-  testAccountDataEherkenning,
-} from '../../universal/config/auth.development.ts';
 import { apiSuccessResult } from '../../universal/helpers/api.ts';
 import { getReturnToUrl } from '../auth/auth-after-redirect-returnto.ts';
 import {
@@ -24,6 +19,11 @@ import {
   OIDC_SESSION_MAX_AGE_SECONDS,
   TOKEN_ID_ATTRIBUTE,
 } from '../auth/auth-config.ts';
+import {
+  testAccountDataDigid,
+  testAccountDataEherkenning,
+} from '../auth/auth-development.ts';
+import type { TestUserData } from '../auth/auth-development.ts';
 import {
   cleanTestUsername,
   signDevelopmentToken,

--- a/src/server/services/decos/decos-route-handlers.ts
+++ b/src/server/services/decos/decos-route-handlers.ts
@@ -8,13 +8,13 @@ import {
   ZAAK_SUB_TYPE,
 } from './decos-service.ts';
 import type { DecosZaakBase } from './decos-types.ts';
-import type { TestUserData } from '../../../universal/config/auth.development.ts';
+import { IS_PRODUCTION } from '../../../universal/config/env.ts';
+import { apiSuccessResult } from '../../../universal/helpers/api.ts';
+import type { TestUserData } from '../../auth/auth-development.ts';
 import {
   testAccountDataDigid as testAccountDataDigid,
   testAccountDataEherkenning as testAccountDataEherkenning,
-} from '../../../universal/config/auth.development.ts';
-import { IS_PRODUCTION } from '../../../universal/config/env.ts';
-import { apiSuccessResult } from '../../../universal/helpers/api.ts';
+} from '../../auth/auth-development.ts';
 import type { AuthProfileAndToken } from '../../auth/auth-types.ts';
 import type { RequestWithQueryParams } from '../../routing/route-helpers.ts';
 import {


### PR DESCRIPTION
Move test account data imports from universal to server directory and remove deprecated auth.development.ts