### PR TITLE
MIJN-13127-BUG: Remove double slash in tracking url

### DIFF
--- a/src/client/pages/Thema/Jeugd/Jeugd-thema-config.ts
+++ b/src/client/pages/Thema/Jeugd/Jeugd-thema-config.ts
@@ -59,7 +59,7 @@ export const themaConfig: ThemaConfigJeugd = {
       path: `${detailRouteBase}/:voorziening/:id`,
       documentTitle: `Voorziening | ${THEMA_TITLE}`,
       trackingUrl: (params) =>
-        `/${detailRouteBase}/${params?.voorziening ?? ''}`,
+        `${detailRouteBase}/${params?.voorziening ?? ''}`,
     },
   },
 } as const;


### PR DESCRIPTION
Solves the issue of sending double slashes to PiwikPro. See example below


```
Page view
Page title: Voorziening | Onderwijs en Jeugd
Page URL: https://az-acc.mijn.amsterdam.nl/mijn-amsterdam//jeugd/voorziening/aangepast-groepsvervoer/
```