### PR TITLE
MIJN-13038-FEATURE: Change loading checks to cope for non existing state

### DIFF
--- a/src/client/config/thema-types.ts
+++ b/src/client/config/thema-types.ts
@@ -12,7 +12,7 @@ export type WithPageConfig<K extends string, T extends object = object> = {
 };
 
 export type IsThemaVisibleFN = (
-  appState: AppState,
+  appState: Partial<AppState>,
   profileType?: ProfileType
 ) => boolean;
 

--- a/src/client/pages/Thema/AVG/AVG-render-config.tsx
+++ b/src/client/pages/Thema/AVG/AVG-render-config.tsx
@@ -4,7 +4,6 @@ import { default as AvgIcon } from './AvgIcon.svg?react';
 import { AVGList } from './AVGList.tsx';
 import { AVGThema } from './AVGThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,7 +33,7 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.AVG) &&

--- a/src/client/pages/Thema/Afis/Afis-render-config.tsx
+++ b/src/client/pages/Thema/Afis/Afis-render-config.tsx
@@ -6,7 +6,6 @@ import { default as AfisIcon } from './AfisIcon.svg?react';
 import { AfisList } from './AfisList.tsx';
 import { AfisThema } from './AfisThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -46,7 +45,7 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   redactedScope: themaConfig.redactedScope,
   profileTypes: themaConfig.profileTypes,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.AFIS) &&

--- a/src/client/pages/Thema/Afval/Afval-render-config.tsx
+++ b/src/client/pages/Thema/Afval/Afval-render-config.tsx
@@ -2,7 +2,6 @@ import { themaConfig } from './Afval-thema-config.ts';
 import { default as AfvalIcon } from './AfvalIcon.svg?react';
 import { AfvalThemaPagina } from './AfvalThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -22,13 +21,13 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return !!(
       themaConfig.featureToggle.active &&
       !isLoading(appState.AFVAL) &&
       !isLoading(appState.MY_LOCATION) &&
-      appState.MY_LOCATION.content?.some((location) => location.mokum) &&
-      appState.AFVAL.content?.length
+      appState.MY_LOCATION?.content?.some((location) => location.mokum) &&
+      appState.AFVAL?.content?.length
     );
   },
   IconSVG: AfvalIcon,

--- a/src/client/pages/Thema/Belastingen/Belastingen-render-config.tsx
+++ b/src/client/pages/Thema/Belastingen/Belastingen-render-config.tsx
@@ -16,12 +16,12 @@ export const menuItem: ThemaMenuItem = {
   },
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState, profileType) {
+  isActive(appState, profileType) {
     return (
       themaConfig.featureToggle.active &&
       (profileType === 'commercial' ||
         (!isLoading(appState.BELASTINGEN) &&
-          !!appState.BELASTINGEN.content?.isKnown))
+          !!appState.BELASTINGEN?.content?.isKnown))
     );
   },
   IconSVG: BelastingenIcon,

--- a/src/client/pages/Thema/Bezwaren/Bezwaren-render-config.tsx
+++ b/src/client/pages/Thema/Bezwaren/Bezwaren-render-config.tsx
@@ -4,7 +4,6 @@ import { default as BezwarenIcon } from './BezwarenIcon.svg?react';
 import { BezwarenList } from './BezwarenList.tsx';
 import { BezwarenThema } from './BezwarenThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,11 +33,11 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   redactedScope: themaConfig.redactedScope,
   profileTypes: themaConfig.profileTypes,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.BEZWAREN) &&
-      !!appState.BEZWAREN.content?.length
+      !!appState.BEZWAREN?.content?.length
     );
   },
   IconSVG: BezwarenIcon,

--- a/src/client/pages/Thema/Bodem/Bodem-render-config.tsx
+++ b/src/client/pages/Thema/Bodem/Bodem-render-config.tsx
@@ -4,7 +4,6 @@ import { default as BodemIcon } from './BodemIcon.svg?react';
 import { BodemList } from './BodemList.tsx';
 import { BodemThema } from './BodemThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,11 +33,11 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.BODEM) &&
-      !!appState.BODEM.content?.length
+      !!appState.BODEM?.content?.length
     );
   },
   IconSVG: BodemIcon,

--- a/src/client/pages/Thema/Erfpacht/Erfpacht-render-config.tsx
+++ b/src/client/pages/Thema/Erfpacht/Erfpacht-render-config.tsx
@@ -72,12 +72,12 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     const content = appState.ERFPACHT?.content;
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.ERFPACHT) &&
-      content !== null &&
+      !!content &&
       (('dossiers' in content && !!content.dossiers.dossiers?.length) ||
         !!content?.isKnown)
     );

--- a/src/client/pages/Thema/HLI/HLI-render-config.tsx
+++ b/src/client/pages/Thema/HLI/HLI-render-config.tsx
@@ -56,7 +56,7 @@ export const menuItem: ThemaMenuItem<typeof themaConfig.id> = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     const hasStadspas =
       !!appState.HLI?.content?.stadspas?.stadspassen?.length &&
       themaConfig.featureToggle.stadspas.active;

--- a/src/client/pages/Thema/Horeca/Horeca-render-config.tsx
+++ b/src/client/pages/Thema/Horeca/Horeca-render-config.tsx
@@ -4,7 +4,6 @@ import { default as HorecaIcon } from './HorecaIcon.svg?react';
 import { HorecaList } from './HorecaList.tsx';
 import { HorecaThema } from './HorecaThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,11 +33,11 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.HORECA) &&
-      !!appState.HORECA.content?.length
+      !!appState.HORECA?.content?.length
     );
   },
   IconSVG: HorecaIcon,

--- a/src/client/pages/Thema/Jeugd/Jeugd-render-config.tsx
+++ b/src/client/pages/Thema/Jeugd/Jeugd-render-config.tsx
@@ -4,7 +4,6 @@ import { default as JeugdIcon } from './JeugdIcon.svg?react';
 import { JeugdList } from './JeugdList.tsx';
 import { JeugdThemaPagina } from './JeugdThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import type { AppState } from '../../../../universal/types/App.types.ts';
 import type { ThemaMenuItem } from '../../../config/thema-types.ts';
 
 export const JeugdRoutes = [
@@ -30,11 +29,11 @@ export const menuItem: ThemaMenuItem = {
   id: themaConfig.id,
   redactedScope: themaConfig.redactedScope,
   profileTypes: themaConfig.profileTypes,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.JEUGD) &&
-      !!appState.JEUGD.content?.length
+      !!appState.JEUGD?.content?.length
     );
   },
   to: themaConfig.route.path,

--- a/src/client/pages/Thema/Klachten/Klachten-render-config.tsx
+++ b/src/client/pages/Thema/Klachten/Klachten-render-config.tsx
@@ -4,7 +4,6 @@ import { default as KlachtenIcon } from './KlachtenIcon.svg?react';
 import { KlachtenList } from './KlachtenList.tsx';
 import { KlachtenThema } from './KlachtenThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,11 +33,11 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.KLACHTEN) &&
-      !!appState.KLACHTEN.content?.length
+      !!appState.KLACHTEN?.content?.length
     );
   },
   IconSVG: KlachtenIcon,

--- a/src/client/pages/Thema/Krefia/Krefia-render-config.tsx
+++ b/src/client/pages/Thema/Krefia/Krefia-render-config.tsx
@@ -2,7 +2,6 @@ import { themaConfig } from './Krefia-thema-config.ts';
 import { default as KrefiaIcon } from './KrefiaIcon.svg?react';
 import { KrefiaThema } from './KrefiaThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -22,11 +21,11 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.KREFIA) &&
-      !!appState.KREFIA.content?.deepLinks.length
+      !!appState.KREFIA?.content?.deepLinks.length
     );
   },
   IconSVG: KrefiaIcon,

--- a/src/client/pages/Thema/Krefia/Krefia-render-config.tsx
+++ b/src/client/pages/Thema/Krefia/Krefia-render-config.tsx
@@ -25,7 +25,7 @@ export const menuItem: ThemaMenuItem = {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.KREFIA) &&
-      !!appState.KREFIA?.content?.deepLinks.length
+      !!appState.KREFIA?.content?.deepLinks?.length
     );
   },
   IconSVG: KrefiaIcon,

--- a/src/client/pages/Thema/Milieuzone/Milieuzone-render-config.tsx
+++ b/src/client/pages/Thema/Milieuzone/Milieuzone-render-config.tsx
@@ -12,7 +12,7 @@ export const menuItem: ThemaMenuItem = {
   },
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.MILIEUZONE) &&

--- a/src/client/pages/Thema/Overtredingen/Overtredingen-render-config.tsx
+++ b/src/client/pages/Thema/Overtredingen/Overtredingen-render-config.tsx
@@ -12,7 +12,7 @@ export const menuItem: ThemaMenuItem = {
   },
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.OVERTREDINGEN) &&

--- a/src/client/pages/Thema/Parkeren/Parkeren-render-config.tsx
+++ b/src/client/pages/Thema/Parkeren/Parkeren-render-config.tsx
@@ -40,7 +40,7 @@ export const menuItem: ThemaMenuItem = {
   },
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     const hasDecosParkeerVergunningen =
       !!appState.PARKEREN?.content?.vergunningen?.length;
     return (

--- a/src/client/pages/Thema/Profile/Profile-render-config.tsx
+++ b/src/client/pages/Thema/Profile/Profile-render-config.tsx
@@ -6,7 +6,6 @@ import { VvEDetail } from './private/VvEDetail.tsx';
 import { themaConfig } from './Profile-thema-config.ts';
 import { default as ProfilePrivateIcon } from './ProfilePrivateIcon.svg?react';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import type { AppState } from '../../../../universal/types/App.types.ts';
 import type { ThemaMenuItem } from '../../../config/thema-types.ts';
 
 export const ProfileRoutes = [
@@ -29,11 +28,11 @@ export const menuItems: ThemaMenuItem[] = [
     to: themaConfig.BRP.route.path,
     profileTypes: themaConfig.BRP.profileTypes,
     redactedScope: themaConfig.BRP.redactedScope,
-    isActive(appState: AppState) {
+    isActive(appState) {
       return (
-        (!isLoading(appState.BRP) && !!appState.BRP.content?.persoon) ||
+        (!isLoading(appState.BRP) && !!appState.BRP?.content?.persoon) ||
         (!isLoading(appState.KLANT_CONTACT) &&
-          !!appState.KLANT_CONTACT.content?.contactmomenten?.length)
+          !!appState.KLANT_CONTACT?.content?.contactmomenten?.length)
       );
     },
     IconSVG: ProfilePrivateIcon,
@@ -44,12 +43,12 @@ export const menuItems: ThemaMenuItem[] = [
     to: themaConfig.KVK.route.path,
     redactedScope: themaConfig.KVK.redactedScope,
     profileTypes: themaConfig.KVK.profileTypes,
-    isActive(appState: AppState) {
+    isActive(appState) {
       return (
         !isLoading(appState.KVK) &&
         !!(
-          appState.KVK.content?.onderneming ||
-          appState.KVK.content?.vestigingen?.length
+          appState.KVK?.content?.onderneming ||
+          appState.KVK?.content?.vestigingen?.length
         )
       );
     },

--- a/src/client/pages/Thema/Subsidies/Subsidies-render-config.tsx
+++ b/src/client/pages/Thema/Subsidies/Subsidies-render-config.tsx
@@ -12,11 +12,11 @@ export const menuItem: ThemaMenuItem = {
   },
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.SUBSIDIES) &&
-      !!appState.SUBSIDIES.content?.isKnown
+      !!appState.SUBSIDIES?.content?.isKnown
     );
   },
   IconSVG: SubsidiesIcon,

--- a/src/client/pages/Thema/Svwi/Svwi-render-config.tsx
+++ b/src/client/pages/Thema/Svwi/Svwi-render-config.tsx
@@ -17,7 +17,7 @@ export const menuItem: ThemaMenuItem<typeof themaId> = {
   },
   redactedScope: 'full',
   profileTypes: ['private', 'commercial'],
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       featureToggle.svwiActive &&
       !isLoading(appState.SVWI) &&

--- a/src/client/pages/Thema/ToeristischeVerhuur/ToeristischeVerhuur-render-config.tsx
+++ b/src/client/pages/Thema/ToeristischeVerhuur/ToeristischeVerhuur-render-config.tsx
@@ -4,7 +4,6 @@ import { default as ToeristischeVerhuurIcon } from './ToeristischeVerhuurIcon.sv
 import { ToeristischeVerhuurList } from './ToeristischeVerhuurList.tsx';
 import { ToeristischeVerhuurThema } from './ToeristischeVerhuurThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,7 +33,7 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     const { lvvRegistraties, vakantieverhuurVergunningen, bbVergunningen } =
       appState.TOERISTISCHE_VERHUUR?.content ?? {};
     const hasRegistraties = !!lvvRegistraties?.length;

--- a/src/client/pages/Thema/Varen/Varen-render-config.tsx
+++ b/src/client/pages/Thema/Varen/Varen-render-config.tsx
@@ -5,7 +5,6 @@ import { default as VarenIcon } from './VarenIcon.svg?react';
 import { VarenList } from './VarenList.tsx';
 import { VarenThema } from './VarenThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -40,7 +39,7 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       !isLoading(appState.VAREN) &&
       (!!appState.VAREN?.content?.reder ||

--- a/src/client/pages/Thema/Vergunningen/Vergunningen-render-config.tsx
+++ b/src/client/pages/Thema/Vergunningen/Vergunningen-render-config.tsx
@@ -4,7 +4,6 @@ import { default as VergunningenIcon } from './VergunningenIcon.svg?react';
 import { VergunningenList } from './VergunningenList.tsx';
 import { VergunningenThema } from './VergunningenThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,11 +33,11 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.VERGUNNINGEN) &&
-      !!appState.VERGUNNINGEN.content?.length
+      !!appState.VERGUNNINGEN?.content?.length
     );
   },
   IconSVG: VergunningenIcon,

--- a/src/client/pages/Thema/Zorg/Zorg-render-config.tsx
+++ b/src/client/pages/Thema/Zorg/Zorg-render-config.tsx
@@ -4,7 +4,6 @@ import { default as ZorgIcon } from './ZorgIcon.svg?react';
 import { ZorgList } from './ZorgList.tsx';
 import { ZorgThema } from './ZorgThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
-import { type AppState } from '../../../../universal/types/App.types.ts';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -34,11 +33,11 @@ export const menuItem: ThemaMenuItem = {
   to: themaConfig.route.path,
   profileTypes: themaConfig.profileTypes,
   redactedScope: themaConfig.redactedScope,
-  isActive(appState: AppState) {
+  isActive(appState) {
     return (
       themaConfig.featureToggle.active &&
       !isLoading(appState.WMO) &&
-      !!appState.WMO.content?.length
+      !!appState.WMO?.content?.length
     );
   },
   IconSVG: ZorgIcon,

--- a/src/universal/helpers/api.ts
+++ b/src/universal/helpers/api.ts
@@ -53,11 +53,10 @@ export type ApiResponsePromise<T> = Promise<ApiResponse<T>>;
 export function isLoading(apiResponseData: ApiResponse_DEPRECATED<unknown>) {
   // If no responseData was found, assumes it's still loading
   return !!(
-    (!apiResponseData && !isError(apiResponseData)) ||
+    !apiResponseData ||
     !!(apiResponseData?.status === 'PRISTINE' && apiResponseData.isActive)
   );
 }
-
 export function isOk(apiResponseData: ApiResponse_DEPRECATED<unknown>) {
   return apiResponseData?.status === 'OK';
 }

--- a/src/universal/helpers/api.ts
+++ b/src/universal/helpers/api.ts
@@ -50,19 +50,19 @@ export type ApiResponse<T> =
 
 export type ApiResponsePromise<T> = Promise<ApiResponse<T>>;
 
-export function isLoading(apiResponseData: ApiResponse_DEPRECATED<unknown>) {
+export function isLoading(apiResponseData?: ApiResponse_DEPRECATED<unknown>) {
   // If no responseData was found, assumes it's still loading
   return !!(
     !apiResponseData ||
     !!(apiResponseData?.status === 'PRISTINE' && apiResponseData.isActive)
   );
 }
-export function isOk(apiResponseData: ApiResponse_DEPRECATED<unknown>) {
+export function isOk(apiResponseData?: ApiResponse_DEPRECATED<unknown>) {
   return apiResponseData?.status === 'OK';
 }
 
 export function isError(
-  apiResponseData: ApiResponse_DEPRECATED<unknown>,
+  apiResponseData?: ApiResponse_DEPRECATED<unknown>,
   includeFailedDependencies: boolean = true
 ) {
   return (


### PR DESCRIPTION
By treating appState as partial we are forced to check for existence of the appState. Especially in FE integration tests this is useful, we are less likely to encounter hard to solve state bugs.

Also:
- Reduces type imports
- Simplifies `isLoading`
