### PR TITLE
MIJN-13282-BUG: Loading content rendert boven zoekresultaten 

### DIFF
--- a/src/client/pages/Dashboard/DashboardHeader.module.scss
+++ b/src/client/pages/Dashboard/DashboardHeader.module.scss
@@ -39,4 +39,5 @@
   @media screen and (min-width: $ams-breakpoint-medium) {
     width: 63%;
   }
+  z-index: z-index(main-header-searchbar);
 }


### PR DESCRIPTION
Deze PR voorkomt dat de inhoud van de pagina over de zoekresultaten heen wordt getoond.

Dit gebeurde wanneer de stacking context veranderde. Bijvoorbeeld bij het tonen van de componenten loading content en afspraken.

De oplossing sluit aan op de globale z-index-configuratie die Tim heeft ontwikkeld.