### PR TITLE
MIJN-13314-FEATURE: Amsapp login flow universal

### DIFF
--- a/src/server/auth/auth-after-redirect-returnto.ts
+++ b/src/server/auth/auth-after-redirect-returnto.ts
@@ -7,12 +7,14 @@ import {
   generateFullApiUrlBFF,
   generateMaFrontendUrl,
 } from '../routing/route-helpers.ts';
+import { routes as amsappAuthRoutes } from '../services/amsapp/auth/amsapp-auth-service-config.ts';
 import { routes as amsappNotificationsRoutes } from '../services/amsapp/notifications/amsapp-notifications-service-config.ts';
 import { routes as amsappStadspasRoutes } from '../services/amsapp/stadspas/amsapp-stadspas-service-config.ts';
 
 // Return-to-key after login for getting the administration number of the stadspas.
 export const RETURNTO_AMSAPP_STADSPAS_ADMINISTRATIENUMMER =
   'amsapp-stadspas-administratienummer';
+export const RETURNTO_AMSAPP_AUTH_CALLBACK = 'amsapp-auth-callback';
 // Return-to-key after logout for redirecting to the landing page of the stadspas app.
 export const RETURNTO_AMSAPP_STADSPAS_APP_LANDING = 'amsapp-stadspas-landing';
 
@@ -46,6 +48,16 @@ export function getReturnToUrl(
           token:
             typeof queryParams['amsapp-session-token'] === 'string'
               ? queryParams['amsapp-session-token']
+              : '',
+        }
+      );
+    case RETURNTO_AMSAPP_AUTH_CALLBACK:
+      return generateFullApiUrlBFF(
+        amsappAuthRoutes.public.AMSAPP_AUTH_CALLBACK,
+        {
+          loginId:
+            typeof queryParams['amsapp-login-id'] === 'string'
+              ? queryParams['amsapp-login-id']
               : '',
         }
       );

--- a/src/server/auth/auth-helpers.test.ts
+++ b/src/server/auth/auth-helpers.test.ts
@@ -3,6 +3,7 @@ import type { Request } from 'express';
 
 import { getReturnToUrl } from './auth-after-redirect-returnto.ts';
 import {
+  RETURNTO_AMSAPP_AUTH_CALLBACK,
   RETURNTO_AMSAPP_STADSPAS_ADMINISTRATIENUMMER,
   RETURNTO_AMSAPP_STADSPAS_APP_LANDING,
 } from './auth-after-redirect-returnto.ts';
@@ -291,6 +292,17 @@ describe('auth-helpers', () => {
 
       expect(url).toBe(
         'http://bff-api-host/api/v1/services/amsapp/stadspas/app-landing'
+      );
+    });
+
+    test('getReturnToUrl should return the correct RETURNTO_AMSAPP_AUTH_CALLBACK url', () => {
+      const url = getReturnToUrl({
+        returnTo: RETURNTO_AMSAPP_AUTH_CALLBACK,
+        'amsapp-login-id': 'login-id-123',
+      });
+
+      expect(url).toBe(
+        'http://bff-api-host/api/v1/services/amsapp/auth/callback/login-id-123'
       );
     });
 

--- a/src/server/config/feature-toggles.ts
+++ b/src/server/config/feature-toggles.ts
@@ -3,6 +3,8 @@ import { IS_PRODUCTION } from '../../universal/config/env.ts';
 // Is mutated by the Appconfiguration. Locally this object will be used as is.
 export const featureToggle = {
   ['AFIS.EMandates']: true,
+  ['AMSAPP.universalAuth']: !IS_PRODUCTION,
+  ['AMSAPP.universalAuth.servicesAllAccess']: !IS_PRODUCTION,
   ['AMSAPP.notificationService']: true,
   ['BRP.aantalBewonersOpAdresTonen']: true,
   ['USER_FEEDBACK.fetchSurvey']: true,

--- a/src/server/routing/app-router-development.ts
+++ b/src/server/routing/app-router-development.ts
@@ -141,7 +141,11 @@ authRouterDevelopment.get(
       authMethod === 'digid' ? 'MA_TEST_ACCOUNTS' : 'MA_TEST_ACCOUNTS_EH';
 
     if (!req.query.username) {
-      return sendRenderedTestAccountTable(res, authMethod);
+      return sendRenderedTestAccountTable(
+        res,
+        authMethod,
+        req.query as Record<string, string | undefined>
+      );
     }
 
     const profileId = getValueFromEnvByKey(envKey, req.query.username);
@@ -216,7 +220,8 @@ function transformAccount(account: TestUserAccount): TestUserAccount {
 
 async function sendRenderedTestAccountTable(
   res: Response,
-  authMethod: AuthMethod
+  authMethod: AuthMethod,
+  loginQueryParams: Record<string, string | undefined> = {}
 ) {
   const envKey =
     authMethod === 'digid' ? 'MA_TEST_ACCOUNTS' : 'MA_TEST_ACCOUNTS_EH';
@@ -287,7 +292,8 @@ async function sendRenderedTestAccountTable(
 
   const accountsWithLoginLink = addLoginLinkToUsernameProp(
     testAccountsData,
-    authMethod
+    authMethod,
+    loginQueryParams
   );
 
   const renderProps = {
@@ -299,16 +305,30 @@ async function sendRenderedTestAccountTable(
   return res.render('select-test-account', renderProps);
 }
 
+function filterUndefinedQueryParams(
+  queryParams: Record<string, string | undefined>
+) {
+  return Object.fromEntries(
+    Object.entries(queryParams).filter(
+      ([, value]): value is string => typeof value === 'string'
+    )
+  );
+}
+
 function addLoginLinkToUsernameProp(
   testAccountData: TestUserData,
-  authMethod: AuthProfile['authMethod']
+  authMethod: AuthProfile['authMethod'],
+  loginQueryParams: Record<string, string | undefined>
 ) {
   const authRoute = `${authMethod === 'digid' ? authRoutes.AUTH_LOGIN_DIGID : authRoutes.AUTH_LOGIN_EHERKENNING}`;
 
   return testAccountData.accounts.map((account) => {
-    const authLoginRoute = generateFullApiUrlBFF(authRoute, [
-      { username: account.username },
-    ]);
+    const queryParams = {
+      ...filterUndefinedQueryParams(loginQueryParams),
+      username: account.username,
+    };
+
+    const authLoginRoute = generateFullApiUrlBFF(authRoute, [queryParams]);
     return {
       ...account,
       username: `<a href="${authLoginRoute}" class="test-account-name">${account.username.replace(/^[a-zA-Z]_/, '')}</a>`,

--- a/src/server/routing/app-router-development.ts
+++ b/src/server/routing/app-router-development.ts
@@ -136,7 +136,7 @@ authRouterDevelopment.use(async (req, res, next) => {
   if (hasSessionCookie(req)) {
     try {
       await ensureDevelopmentAuthContext(req);
-    } catch (error) {
+    } catch (_error) {
       res.clearCookie(OIDC_SESSION_COOKIE_NAME);
       return sendUnauthorized(res);
     }

--- a/src/server/routing/app-router-development.ts
+++ b/src/server/routing/app-router-development.ts
@@ -309,9 +309,7 @@ function filterUndefinedQueryParams(
   queryParams: Record<string, string | undefined>
 ) {
   return Object.fromEntries(
-    Object.entries(queryParams).filter(
-      ([, value]): value is string => typeof value === 'string'
-    )
+    Object.entries(queryParams).filter(([, value]) => typeof value === 'string')
   );
 }
 

--- a/src/server/routing/app-router-development.ts
+++ b/src/server/routing/app-router-development.ts
@@ -39,23 +39,12 @@ export const authRouterDevelopment = createBFFRouter({ id: 'router-dev' });
 
 function parseDevelopmentSessionCookie(sessionCookieValue: string) {
   try {
-    const parsed = JSON.parse(
+    return JSON.parse(
       Buffer.from(sessionCookieValue, 'base64').toString('ascii')
     ) as AuthProfile;
-
-    if (
-      parsed &&
-      typeof parsed.id === 'string' &&
-      typeof parsed.sid === 'string' &&
-      (parsed.authMethod === 'digid' || parsed.authMethod === 'eherkenning') &&
-      (parsed.profileType === 'private' || parsed.profileType === 'commercial')
-    ) {
-      return parsed;
-    }
   } catch {
     // Ignore parsing errors; this cookie format only exists in local development.
   }
-
   return null;
 }
 
@@ -68,7 +57,7 @@ export async function ensureDevelopmentAuthContext(req: Request) {
     return;
   }
 
-  const sessionCookieValue = req.cookies?.[OIDC_SESSION_COOKIE_NAME] ?? '';
+  const sessionCookieValue = req.cookies?.[OIDC_SESSION_COOKIE_NAME] ?? null;
   if (!sessionCookieValue) {
     return;
   }

--- a/src/server/routing/app-router-development.ts
+++ b/src/server/routing/app-router-development.ts
@@ -36,6 +36,46 @@ import { countLoggedInVisit } from '../services/admin/admin-visitors.ts';
 
 export const authRouterDevelopment = createBFFRouter({ id: 'router-dev' });
 
+function parseDevelopmentSessionCookie(sessionCookieValue: string) {
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(sessionCookieValue, 'base64').toString('ascii')
+    ) as AuthProfile;
+
+    if (
+      parsed &&
+      typeof parsed.id === 'string' &&
+      typeof parsed.sid === 'string' &&
+      (parsed.authMethod === 'digid' || parsed.authMethod === 'eherkenning') &&
+      (parsed.profileType === 'private' || parsed.profileType === 'commercial')
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Ignore parsing errors; this cookie format only exists in local development.
+  }
+
+  return null;
+}
+
+export async function ensureDevelopmentAuthContext(req: Request) {
+  if (getAuth(req)) {
+    return;
+  }
+
+  const sessionCookieValue = req.cookies?.[OIDC_SESSION_COOKIE_NAME] ?? '';
+  if (!sessionCookieValue) {
+    return;
+  }
+
+  const authProfile = parseDevelopmentSessionCookie(sessionCookieValue);
+  if (!authProfile) {
+    return;
+  }
+
+  await createOIDCStub(req, authProfile);
+}
+
 export async function createOIDCStub(
   req: Request,
   authProfile: AuthProfile,
@@ -94,12 +134,8 @@ function getPredefinedRedirectUrl<
 
 authRouterDevelopment.use(async (req, res, next) => {
   if (hasSessionCookie(req)) {
-    const cookieValue = req.cookies[OIDC_SESSION_COOKIE_NAME];
     try {
-      await createOIDCStub(
-        req,
-        JSON.parse(Buffer.from(cookieValue, 'base64').toString('ascii'))
-      );
+      await ensureDevelopmentAuthContext(req);
     } catch (error) {
       res.clearCookie(OIDC_SESSION_COOKIE_NAME);
       return sendUnauthorized(res);

--- a/src/server/routing/app-router-development.ts
+++ b/src/server/routing/app-router-development.ts
@@ -33,6 +33,7 @@ import {
   mergeWithDynamicTableHeaders,
 } from '../helpers/test-accounts.ts';
 import { countLoggedInVisit } from '../services/admin/admin-visitors.ts';
+import { featureToggle } from '../services/amsapp/auth/amsapp-auth-service-config.ts';
 
 export const authRouterDevelopment = createBFFRouter({ id: 'router-dev' });
 
@@ -59,6 +60,10 @@ function parseDevelopmentSessionCookie(sessionCookieValue: string) {
 }
 
 export async function ensureDevelopmentAuthContext(req: Request) {
+  if (!featureToggle.amsAppUniversalAuthIsActive) {
+    return;
+  }
+
   if (getAuth(req)) {
     return;
   }

--- a/src/server/routing/app-router-private-auth-context.test.ts
+++ b/src/server/routing/app-router-private-auth-context.test.ts
@@ -16,6 +16,22 @@ const DIGID_PROFILE: AuthProfile = {
   id: 'x1',
 };
 
+type PrivateAuthRequest = Request & {
+  headers: Record<string, string>;
+  path: string;
+  url: string;
+};
+
+function createPrivateAuthRequest(headers: Record<string, string>) {
+  const req = RequestMock.new().get() as PrivateAuthRequest;
+  Object.assign(req, {
+    headers,
+    path: '/services/amsapp/auth/services/all',
+    url: '/services/amsapp/auth/services/all',
+  });
+  return req;
+}
+
 describe('app-router-private-auth-context', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -26,14 +42,9 @@ describe('app-router-private-auth-context', () => {
       'base64'
     );
 
-    const req = RequestMock.new().get() as Request;
-    (req as Request & { headers: Record<string, string> }).headers = {
+    const req = createPrivateAuthRequest({
       [AMSAPP_SESSION_TOKEN_HEADER]: sessionToken,
-    };
-    (req as Request & { path: string; url: string }).path =
-      '/services/amsapp/auth/services/all';
-    (req as Request & { path: string; url: string }).url =
-      '/services/amsapp/auth/services/all';
+    });
 
     const resMock = ResponseMock.new();
     const next = vi.fn();
@@ -50,14 +61,9 @@ describe('app-router-private-auth-context', () => {
       'base64'
     );
 
-    const req = RequestMock.new().get() as Request;
-    (req as Request & { headers: Record<string, string> }).headers = {
+    const req = createPrivateAuthRequest({
       authorization: `Bearer ${sessionToken}`,
-    };
-    (req as Request & { path: string; url: string }).path =
-      '/services/amsapp/auth/services/all';
-    (req as Request & { path: string; url: string }).url =
-      '/services/amsapp/auth/services/all';
+    });
 
     const resMock = ResponseMock.new();
     const next = vi.fn();

--- a/src/server/routing/app-router-private-auth-context.test.ts
+++ b/src/server/routing/app-router-private-auth-context.test.ts
@@ -1,0 +1,71 @@
+import type { Request } from 'express';
+
+import {
+  AMSAPP_SESSION_TOKEN_HEADER,
+  privateNetworkAuthContextMiddleware,
+} from './app-router-private-auth-context.ts';
+import { RequestMock, ResponseMock } from '../../testing/utils.ts';
+import { OIDC_SESSION_COOKIE_NAME } from '../auth/auth-config.ts';
+import { getAuth } from '../auth/auth-helpers.ts';
+import type { AuthProfile } from '../auth/auth-types.ts';
+
+const DIGID_PROFILE: AuthProfile = {
+  sid: 'e6ed38c3-a44a-4c16-97c1-89d7ebfca095',
+  profileType: 'private',
+  authMethod: 'digid',
+  id: 'x1',
+};
+
+describe('app-router-private-auth-context', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('uses x-amsapp-session-token as __MA-appSession cookie', async () => {
+    const sessionToken = Buffer.from(JSON.stringify(DIGID_PROFILE)).toString(
+      'base64'
+    );
+
+    const req = RequestMock.new().get() as Request;
+    (req as Request & { headers: Record<string, string> }).headers = {
+      [AMSAPP_SESSION_TOKEN_HEADER]: sessionToken,
+    };
+    (req as Request & { path: string; url: string }).path =
+      '/services/amsapp/auth/services/all';
+    (req as Request & { path: string; url: string }).url =
+      '/services/amsapp/auth/services/all';
+
+    const resMock = ResponseMock.new();
+    const next = vi.fn();
+
+    await privateNetworkAuthContextMiddleware(req, resMock, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.cookies?.[OIDC_SESSION_COOKIE_NAME]).toBe(sessionToken);
+    expect(getAuth(req)?.profile.id).toBe(DIGID_PROFILE.id);
+  });
+
+  test('ignores bearer token and does not create session cookie', async () => {
+    const sessionToken = Buffer.from(JSON.stringify(DIGID_PROFILE)).toString(
+      'base64'
+    );
+
+    const req = RequestMock.new().get() as Request;
+    (req as Request & { headers: Record<string, string> }).headers = {
+      authorization: `Bearer ${sessionToken}`,
+    };
+    (req as Request & { path: string; url: string }).path =
+      '/services/amsapp/auth/services/all';
+    (req as Request & { path: string; url: string }).url =
+      '/services/amsapp/auth/services/all';
+
+    const resMock = ResponseMock.new();
+    const next = vi.fn();
+
+    await privateNetworkAuthContextMiddleware(req, resMock, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.cookies?.[OIDC_SESSION_COOKIE_NAME]).toBeUndefined();
+    expect(getAuth(req)).toBeNull();
+  });
+});

--- a/src/server/routing/app-router-private-auth-context.ts
+++ b/src/server/routing/app-router-private-auth-context.ts
@@ -90,6 +90,9 @@ export async function privateNetworkAuthContextMiddleware(
   res: Response,
   next: NextFunction
 ) {
+  if (!featureToggle.amsAppUniversalAuthIsActive) {
+    return next();
+  }
   try {
     applyAmsAppSessionTokenAsCookie(req);
 

--- a/src/server/routing/app-router-private-auth-context.ts
+++ b/src/server/routing/app-router-private-auth-context.ts
@@ -8,6 +8,7 @@ import {
   openIdAuth,
 } from '../auth/auth-config.ts';
 import { getAuth } from '../auth/auth-helpers.ts';
+import { featureToggle } from '../services/amsapp/auth/amsapp-auth-service-config.ts';
 
 export const AMSAPP_SESSION_TOKEN_HEADER = 'x-amsapp-session-token';
 
@@ -55,6 +56,10 @@ function appendSessionCookieHeader(req: Request, sessionToken: string) {
 }
 
 function applyAmsAppSessionTokenAsCookie(req: Request) {
+  if (!featureToggle.amsAppUniversalAuthIsActive) {
+    return;
+  }
+
   const token = getHeaderValue(req, AMSAPP_SESSION_TOKEN_HEADER);
   if (!token || req.cookies?.[OIDC_SESSION_COOKIE_NAME]) {
     return;
@@ -66,6 +71,9 @@ function applyAmsAppSessionTokenAsCookie(req: Request) {
 }
 
 async function ensureOidcAuthContext(req: Request, res: Response) {
+  if (!featureToggle.amsAppUniversalAuthIsActive) {
+    return;
+  }
   await new Promise<void>((resolve, reject) => {
     getOidcDigidAuthHandler()(req, res, (error?: unknown) => {
       if (error) {

--- a/src/server/routing/app-router-private-auth-context.ts
+++ b/src/server/routing/app-router-private-auth-context.ts
@@ -1,0 +1,104 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { ensureDevelopmentAuthContext } from './app-router-development.ts';
+import { IS_PRODUCTION } from '../../universal/config/env.ts';
+import {
+  OIDC_SESSION_COOKIE_NAME,
+  oidcConfigDigid,
+  openIdAuth,
+} from '../auth/auth-config.ts';
+import { getAuth } from '../auth/auth-helpers.ts';
+
+export const AMSAPP_SESSION_TOKEN_HEADER = 'x-amsapp-session-token';
+
+let oidcDigidAuthHandler: RequestHandler | null = null;
+
+function getOidcDigidAuthHandler() {
+  if (!oidcDigidAuthHandler) {
+    oidcDigidAuthHandler = openIdAuth(oidcConfigDigid);
+  }
+
+  return oidcDigidAuthHandler;
+}
+
+function getHeaderValue(req: Request, headerName: string): string | undefined {
+  const value = req.headers[headerName];
+
+  if (typeof value === 'string') {
+    return value.trim() || undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const first = value.find((entry) => typeof entry === 'string' && entry);
+    return first?.trim() || undefined;
+  }
+
+  return undefined;
+}
+
+function appendSessionCookieHeader(req: Request, sessionToken: string) {
+  const cookiePair = `${OIDC_SESSION_COOKIE_NAME}=${encodeURIComponent(sessionToken)}`;
+  const existingCookieHeader = req.headers.cookie;
+
+  if (typeof existingCookieHeader === 'string' && existingCookieHeader) {
+    req.headers.cookie = `${existingCookieHeader}; ${cookiePair}`;
+    return;
+  }
+
+  if (Array.isArray(existingCookieHeader) && existingCookieHeader.length > 0) {
+    const first = existingCookieHeader[0] ?? '';
+    req.headers.cookie = `${first}; ${cookiePair}`;
+    return;
+  }
+
+  req.headers.cookie = cookiePair;
+}
+
+function applyAmsAppSessionTokenAsCookie(req: Request) {
+  const token = getHeaderValue(req, AMSAPP_SESSION_TOKEN_HEADER);
+  if (!token || req.cookies?.[OIDC_SESSION_COOKIE_NAME]) {
+    return;
+  }
+
+  req.cookies ??= {};
+  req.cookies[OIDC_SESSION_COOKIE_NAME] = token;
+  appendSessionCookieHeader(req, token);
+}
+
+async function ensureOidcAuthContext(req: Request, res: Response) {
+  await new Promise<void>((resolve, reject) => {
+    getOidcDigidAuthHandler()(req, res, (error?: unknown) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function privateNetworkAuthContextMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    applyAmsAppSessionTokenAsCookie(req);
+
+    if (!req.cookies?.[OIDC_SESSION_COOKIE_NAME]) {
+      return next();
+    }
+
+    if (!IS_PRODUCTION) {
+      await ensureDevelopmentAuthContext(req);
+    }
+
+    if (!getAuth(req)) {
+      await ensureOidcAuthContext(req, res);
+    }
+
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+}

--- a/src/server/routing/app-router-private.ts
+++ b/src/server/routing/app-router-private.ts
@@ -1,5 +1,6 @@
 import { createBFFRouter } from './route-helpers.ts';
 import { afisRouter } from '../services/afis/afis-router.ts';
+import { amsappAuthRouter } from '../services/amsapp/auth/amsapp-auth-router.ts';
 import { amsappNotificationsRouter } from '../services/amsapp/notifications/amsapp-notifications-router.ts';
 import { amsappStadspasRouter } from '../services/amsapp/stadspas/amsapp-stadspas-router.ts';
 import { jzdRouter } from '../services/jzd/jzd-router.ts';
@@ -7,6 +8,7 @@ import { jzdRouter } from '../services/jzd/jzd-router.ts';
 export const router = createBFFRouter({ id: 'router-private-network' });
 
 router.use(
+  amsappAuthRouter.private,
   amsappNotificationsRouter.private,
   amsappStadspasRouter.private,
   jzdRouter.private,

--- a/src/server/routing/app-router-private.ts
+++ b/src/server/routing/app-router-private.ts
@@ -1,11 +1,16 @@
+import { privateNetworkAuthContextMiddleware } from './app-router-private-auth-context.ts';
 import { createBFFRouter } from './route-helpers.ts';
 import { afisRouter } from '../services/afis/afis-router.ts';
+import { AMSAPP_BASE_PATH } from '../services/amsapp/amsapp-constants.ts';
 import { amsappAuthRouter } from '../services/amsapp/auth/amsapp-auth-router.ts';
 import { amsappNotificationsRouter } from '../services/amsapp/notifications/amsapp-notifications-router.ts';
 import { amsappStadspasRouter } from '../services/amsapp/stadspas/amsapp-stadspas-router.ts';
 import { jzdRouter } from '../services/jzd/jzd-router.ts';
 
 export const router = createBFFRouter({ id: 'router-private-network' });
+
+// Allow any route under the AMSAPP_BASE_PATH to have the private network auth context middleware applied, so that the amsapp routers can use the auth context for their routes.
+router.use(AMSAPP_BASE_PATH, privateNetworkAuthContextMiddleware);
 
 router.use(
   amsappAuthRouter.private,

--- a/src/server/routing/app-router-private.ts
+++ b/src/server/routing/app-router-private.ts
@@ -3,14 +3,17 @@ import { createBFFRouter } from './route-helpers.ts';
 import { afisRouter } from '../services/afis/afis-router.ts';
 import { AMSAPP_BASE_PATH } from '../services/amsapp/amsapp-constants.ts';
 import { amsappAuthRouter } from '../services/amsapp/auth/amsapp-auth-router.ts';
+import { featureToggle } from '../services/amsapp/auth/amsapp-auth-service-config.ts';
 import { amsappNotificationsRouter } from '../services/amsapp/notifications/amsapp-notifications-router.ts';
 import { amsappStadspasRouter } from '../services/amsapp/stadspas/amsapp-stadspas-router.ts';
 import { jzdRouter } from '../services/jzd/jzd-router.ts';
 
 export const router = createBFFRouter({ id: 'router-private-network' });
 
-// Allow any route under the AMSAPP_BASE_PATH to have the private network auth context middleware applied, so that the amsapp routers can use the auth context for their routes.
-router.use(AMSAPP_BASE_PATH, privateNetworkAuthContextMiddleware);
+if (featureToggle.amsAppUniversalAuthIsActive) {
+  // Allow any route under the AMSAPP_BASE_PATH to have the private network auth context middleware applied, so that the amsapp routers can use the auth context for their routes.
+  router.use(AMSAPP_BASE_PATH, privateNetworkAuthContextMiddleware);
+}
 
 router.use(
   amsappAuthRouter.private,

--- a/src/server/routing/app-router-protected.ts
+++ b/src/server/routing/app-router-protected.ts
@@ -42,17 +42,20 @@ import { fetchWpiDocument } from '../services/wpi/api-service.ts';
 
 export const router = createBFFRouter({ id: 'router-protected' });
 
-router.get(
-  BffEndpoints.SERVICES_ALL,
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const response = await loadServicesAll(req, res);
-      return res.json(response);
-    } catch (error) {
-      next(error);
-    }
+export async function handleServicesAll(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    const response = await loadServicesAll(req, res);
+    return res.json(response);
+  } catch (error) {
+    return next(error);
   }
-);
+}
+
+router.get(BffEndpoints.SERVICES_ALL, handleServicesAll);
 
 router.get(
   BffEndpoints.SERVICES_TIPS,
@@ -74,7 +77,7 @@ router.get(
     req: RequestWithQueryParams<{
       [key in keyof typeof streamEndpointQueryParamKeys]: string;
     }>,
-    res: Response,
+    _res: Response,
     next: NextFunction
   ) => {
     if (

--- a/src/server/routing/app-router-public-external-consumer.ts
+++ b/src/server/routing/app-router-public-external-consumer.ts
@@ -1,4 +1,5 @@
 import { createBFFRouter } from './route-helpers.ts';
+import { amsappAuthRouter } from '../services/amsapp/auth/amsapp-auth-router.ts';
 import { amsappNotificationsRouter } from '../services/amsapp/notifications/amsapp-notifications-router.ts';
 import { amsappStadspasRouter } from '../services/amsapp/stadspas/amsapp-stadspas-router.ts';
 
@@ -6,4 +7,8 @@ export const router = createBFFRouter({
   id: 'router-public-external-consumer',
 });
 
-router.use(amsappNotificationsRouter.public, amsappStadspasRouter.public);
+router.use(
+  amsappAuthRouter.public,
+  amsappNotificationsRouter.public,
+  amsappStadspasRouter.public
+);

--- a/src/server/services/amsapp/amsapp-service-config.ts
+++ b/src/server/services/amsapp/amsapp-service-config.ts
@@ -3,10 +3,12 @@ import { authRoutes } from '../../auth/auth-routes.ts';
 import { MA_FRONTEND_URL } from '../../config/app.ts';
 import { getFromEnv } from '../../helpers/env.ts';
 import { generateFullApiUrlBFF } from '../../routing/route-helpers.ts';
+import { IS_PRODUCTION } from '../../../universal/config/env.ts';
 
 export const nonce = getFromEnv('BFF_AMSAPP_NONCE')!; // This nonce is whitelisted in the CSP config
 export const baseRenderProps = {
   nonce,
+  showIdentifier: !IS_PRODUCTION,
   urlToImage: `${MA_FRONTEND_URL}/img/logo-amsterdam.svg`,
   urlToCSS: `${MA_FRONTEND_URL}/css/amsapp-landing.css`,
   get logoutUrl() {

--- a/src/server/services/amsapp/amsapp-types.ts
+++ b/src/server/services/amsapp/amsapp-types.ts
@@ -7,6 +7,7 @@ export type ApiError = {
 export type RenderProps = {
   nonce: string;
   promptOpenApp: boolean;
+  showIdentifier?: boolean;
   urlToImage: string;
   urlToCSS: string;
   error?: ApiError;

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
@@ -91,10 +91,8 @@ describe('amsapp-auth-route-handlers', () => {
   });
 
   test('token exchange validates PKCE and returns MA session cookie value', async () => {
-    const codeVerifier = 'mobile-app-code-verifier';
-    const codeChallenge = createHash('sha256')
-      .update(codeVerifier)
-      .digest('base64url');
+    const codeVerifier = 'test';
+    const codeChallenge = 'n4bQgYhMfWWaL-qgxVrQFaO_TxsrC4Is0V1sFbDwCgg'; // createHash('sha256').update(codeVerifier).digest('base64url');
 
     const loginId = createLoginAttempt(codeChallenge);
     const readyRecord = markLoginReady(loginId, 'ma-session-cookie-value');
@@ -137,7 +135,7 @@ describe('amsapp-auth-route-handlers', () => {
     const req = {
       body: {
         authorizationCode: readyRecord?.authorizationCode,
-        codeVerifier: 'other-verifier',
+        codeVerifier: `${codeVerifier}-mismatch`,
       },
     } as Request;
 

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
@@ -102,22 +102,25 @@ describe('amsapp-auth-route-handlers', () => {
     const req = {
       body: {
         authorizationCode: readyRecord?.authorizationCode,
-        codeVerifier: codeVerifier,
+        codeVerifier,
       },
     } as Request;
     const resMock = ResponseMock.new();
 
     await handleAmsAppAuthTokenExchange(req, resMock);
 
-    expect(resMock.send).toHaveBeenCalledWith({
-      status: 'OK',
-      content: {
-        session: {
-          name: OIDC_SESSION_COOKIE_NAME,
-          value: 'ma-session-cookie-value',
-        },
-      },
-    });
+    expect(resMock.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'OK',
+        content: expect.objectContaining({
+          session: expect.objectContaining({
+            name: OIDC_SESSION_COOKIE_NAME,
+            value: 'ma-session-cookie-value',
+            expiresAt: expect.any(Number),
+          }),
+        }),
+      })
+    );
 
     expect(getByLoginId(loginId)).toBeNull();
   });
@@ -163,8 +166,8 @@ describe('amsapp-auth-route-handlers', () => {
 
     const firstReq = {
       body: {
-        authorizationCode: authorizationCode,
-        codeVerifier: codeVerifier,
+        authorizationCode,
+        codeVerifier,
       },
     } as Request;
 
@@ -173,8 +176,8 @@ describe('amsapp-auth-route-handlers', () => {
 
     const secondReq = {
       body: {
-        authorizationCode: authorizationCode,
-        codeVerifier: codeVerifier,
+        authorizationCode,
+        codeVerifier,
       },
     } as Request;
 

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
@@ -31,9 +31,9 @@ describe('amsapp-auth-route-handlers', () => {
     clearAmsAppAuthStore();
   });
 
-  test('login-start stores code_challenge and redirects to DigiD login', async () => {
+  test('login-start stores codeChallenge and redirects to DigiD login', async () => {
     const reqMock = RequestMock.new().setQuery({
-      code_challenge: 'test-code-challenge',
+      codeChallenge: 'test-code-challenge',
     });
     const req = reqMock.get();
     const resMock = ResponseMock.new();
@@ -56,7 +56,7 @@ describe('amsapp-auth-route-handlers', () => {
     expect(storedLoginAttempt?.status).toBe('pending');
   });
 
-  test('callback marks authorization_code ready and returns deeplink', async () => {
+  test('callback marks authorizationCode ready and returns deeplink', async () => {
     const loginId = createLoginAttempt('code-challenge-123');
     const reqMock = RequestMock.new()
       .setParams({ loginId })
@@ -79,7 +79,7 @@ describe('amsapp-auth-route-handlers', () => {
       'amsterdam://mijn-amsterdam/gelukt'
     );
 
-    const authorizationCode = appHref.searchParams.get('authorization_code');
+    const authorizationCode = appHref.searchParams.get('authorizationCode');
     expect(authorizationCode).toBeTruthy();
 
     const storedLoginAttempt = getByLoginId(loginId);
@@ -101,8 +101,8 @@ describe('amsapp-auth-route-handlers', () => {
 
     const req = {
       body: {
-        authorization_code: readyRecord?.authorizationCode,
-        code_verifier: codeVerifier,
+        authorizationCode: readyRecord?.authorizationCode,
+        codeVerifier: codeVerifier,
       },
     } as Request;
     const resMock = ResponseMock.new();
@@ -133,8 +133,8 @@ describe('amsapp-auth-route-handlers', () => {
 
     const req = {
       body: {
-        authorization_code: readyRecord?.authorizationCode,
-        code_verifier: 'other-verifier',
+        authorizationCode: readyRecord?.authorizationCode,
+        codeVerifier: 'other-verifier',
       },
     } as Request;
 
@@ -163,8 +163,8 @@ describe('amsapp-auth-route-handlers', () => {
 
     const firstReq = {
       body: {
-        authorization_code: authorizationCode,
-        code_verifier: codeVerifier,
+        authorizationCode: authorizationCode,
+        codeVerifier: codeVerifier,
       },
     } as Request;
 
@@ -173,8 +173,8 @@ describe('amsapp-auth-route-handlers', () => {
 
     const secondReq = {
       body: {
-        authorization_code: authorizationCode,
-        code_verifier: codeVerifier,
+        authorizationCode: authorizationCode,
+        codeVerifier: codeVerifier,
       },
     } as Request;
 
@@ -185,7 +185,7 @@ describe('amsapp-auth-route-handlers', () => {
     expect(secondRes.send).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'ERROR',
-        message: 'Bad request: Unknown or invalid authorization_code',
+        message: 'Bad request: Unknown or invalid authorizationCode',
         code: 400,
       })
     );

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { Request } from 'express';
 
 import {
@@ -11,9 +13,10 @@ import {
   getByLoginId,
   markLoginReady,
 } from './amsapp-auth-store.ts';
-import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
-import type { AuthProfile } from '../../../auth/auth-types.ts';
 import { RequestMock, ResponseMock } from '../../../../testing/utils.ts';
+import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
+import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
+import type { AuthProfile } from '../../../auth/auth-types.ts';
 
 const DIGID_PROFILE: AuthProfile = {
   sid: 'e6ed38c3-a44a-4c16-97c1-89d7ebfca095',
@@ -55,7 +58,11 @@ describe('amsapp-auth-route-handlers', () => {
 
   test('callback marks authorization_code ready and returns deeplink', async () => {
     const loginId = createLoginAttempt('code-challenge-123');
-    const reqMock = RequestMock.new().setParams({ loginId });
+    const reqMock = RequestMock.new()
+      .setParams({ loginId })
+      .setCookies({
+        [OIDC_SESSION_COOKIE_NAME]: 'ma-session-cookie-value',
+      });
     await reqMock.createOIDCStub(DIGID_PROFILE);
 
     const req = reqMock.get<{ loginId: string }>();
@@ -78,15 +85,24 @@ describe('amsapp-auth-route-handlers', () => {
     const storedLoginAttempt = getByLoginId(loginId);
     expect(storedLoginAttempt?.status).toBe('ready');
     expect(storedLoginAttempt?.authorizationCode).toBe(authorizationCode);
+    expect(storedLoginAttempt?.maSessionCookieValue).toBe(
+      'ma-session-cookie-value'
+    );
   });
 
-  test('token exchange route responds for a ready authorization_code', async () => {
-    const loginId = createLoginAttempt('code-challenge-123');
-    const readyRecord = markLoginReady(loginId);
+  test('token exchange validates PKCE and returns MA session cookie value', async () => {
+    const codeVerifier = 'mobile-app-code-verifier';
+    const codeChallenge = createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    const loginId = createLoginAttempt(codeChallenge);
+    const readyRecord = markLoginReady(loginId, 'ma-session-cookie-value');
 
     const req = {
       body: {
         authorization_code: readyRecord?.authorizationCode,
+        code_verifier: codeVerifier,
       },
     } as Request;
     const resMock = ResponseMock.new();
@@ -96,9 +112,82 @@ describe('amsapp-auth-route-handlers', () => {
     expect(resMock.send).toHaveBeenCalledWith({
       status: 'OK',
       content: {
-        login_id: loginId,
-        status: 'ready',
+        session: {
+          name: OIDC_SESSION_COOKIE_NAME,
+          value: 'ma-session-cookie-value',
+        },
       },
     });
+
+    expect(getByLoginId(loginId)).toBeNull();
+  });
+
+  test('token exchange fails for PKCE mismatch', async () => {
+    const codeVerifier = 'mobile-app-code-verifier';
+    const codeChallenge = createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    const loginId = createLoginAttempt(codeChallenge);
+    const readyRecord = markLoginReady(loginId, 'ma-session-cookie-value');
+
+    const req = {
+      body: {
+        authorization_code: readyRecord?.authorizationCode,
+        code_verifier: 'other-verifier',
+      },
+    } as Request;
+
+    const resMock = ResponseMock.new();
+    await handleAmsAppAuthTokenExchange(req, resMock);
+
+    expect(resMock.status).toHaveBeenCalledWith(400);
+    expect(resMock.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ERROR',
+        code: 400,
+      })
+    );
+    expect(getByLoginId(loginId)?.status).toBe('ready');
+  });
+
+  test('token exchange is one-time use', async () => {
+    const codeVerifier = 'mobile-app-code-verifier';
+    const codeChallenge = createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    const loginId = createLoginAttempt(codeChallenge);
+    const readyRecord = markLoginReady(loginId, 'ma-session-cookie-value');
+    const authorizationCode = readyRecord?.authorizationCode;
+
+    const firstReq = {
+      body: {
+        authorization_code: authorizationCode,
+        code_verifier: codeVerifier,
+      },
+    } as Request;
+
+    const firstRes = ResponseMock.new();
+    await handleAmsAppAuthTokenExchange(firstReq, firstRes);
+
+    const secondReq = {
+      body: {
+        authorization_code: authorizationCode,
+        code_verifier: codeVerifier,
+      },
+    } as Request;
+
+    const secondRes = ResponseMock.new();
+    await handleAmsAppAuthTokenExchange(secondReq, secondRes);
+
+    expect(secondRes.status).toHaveBeenCalledWith(400);
+    expect(secondRes.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ERROR',
+        message: 'Bad request: Unknown or invalid authorization_code',
+        code: 400,
+      })
+    );
   });
 });

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.test.ts
@@ -1,0 +1,104 @@
+import type { Request } from 'express';
+
+import {
+  handleAmsAppAuthCallback,
+  handleAmsAppAuthLoginStart,
+  handleAmsAppAuthTokenExchange,
+} from './amsapp-auth-route-handlers.ts';
+import {
+  clearAmsAppAuthStore,
+  createLoginAttempt,
+  getByLoginId,
+  markLoginReady,
+} from './amsapp-auth-store.ts';
+import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
+import type { AuthProfile } from '../../../auth/auth-types.ts';
+import { RequestMock, ResponseMock } from '../../../../testing/utils.ts';
+
+const DIGID_PROFILE: AuthProfile = {
+  sid: 'e6ed38c3-a44a-4c16-97c1-89d7ebfca095',
+  profileType: 'private',
+  authMethod: 'digid',
+  id: 'x1',
+};
+
+describe('amsapp-auth-route-handlers', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    clearAmsAppAuthStore();
+  });
+
+  test('login-start stores code_challenge and redirects to DigiD login', async () => {
+    const reqMock = RequestMock.new().setQuery({
+      code_challenge: 'test-code-challenge',
+    });
+    const req = reqMock.get();
+    const resMock = ResponseMock.new();
+
+    await handleAmsAppAuthLoginStart(req, resMock);
+
+    expect(resMock.redirect).toHaveBeenCalledOnce();
+
+    const redirectUrl = new URL(resMock.redirect.mock.calls[0][0]);
+    expect(redirectUrl.pathname).toBe('/api/v1/auth/digid/login');
+    expect(redirectUrl.searchParams.get('returnTo')).toBe(
+      RETURNTO_AMSAPP_AUTH_CALLBACK
+    );
+
+    const loginId = redirectUrl.searchParams.get('amsapp-login-id');
+    expect(loginId).toBeTruthy();
+
+    const storedLoginAttempt = getByLoginId(loginId!);
+    expect(storedLoginAttempt?.codeChallenge).toBe('test-code-challenge');
+    expect(storedLoginAttempt?.status).toBe('pending');
+  });
+
+  test('callback marks authorization_code ready and returns deeplink', async () => {
+    const loginId = createLoginAttempt('code-challenge-123');
+    const reqMock = RequestMock.new().setParams({ loginId });
+    await reqMock.createOIDCStub(DIGID_PROFILE);
+
+    const req = reqMock.get<{ loginId: string }>();
+    const resMock = ResponseMock.new();
+
+    await handleAmsAppAuthCallback(req, resMock);
+
+    expect(resMock.render).toHaveBeenCalledOnce();
+    const renderProps = resMock.render.mock.calls[0][1];
+    expect(renderProps.promptOpenApp).toBe(false);
+
+    const appHref = new URL(renderProps.appHref);
+    expect(`${appHref.protocol}//${appHref.host}${appHref.pathname}`).toBe(
+      'amsterdam://mijn-amsterdam/gelukt'
+    );
+
+    const authorizationCode = appHref.searchParams.get('authorization_code');
+    expect(authorizationCode).toBeTruthy();
+
+    const storedLoginAttempt = getByLoginId(loginId);
+    expect(storedLoginAttempt?.status).toBe('ready');
+    expect(storedLoginAttempt?.authorizationCode).toBe(authorizationCode);
+  });
+
+  test('token exchange route responds for a ready authorization_code', async () => {
+    const loginId = createLoginAttempt('code-challenge-123');
+    const readyRecord = markLoginReady(loginId);
+
+    const req = {
+      body: {
+        authorization_code: readyRecord?.authorizationCode,
+      },
+    } as Request;
+    const resMock = ResponseMock.new();
+
+    await handleAmsAppAuthTokenExchange(req, resMock);
+
+    expect(resMock.send).toHaveBeenCalledWith({
+      status: 'OK',
+      content: {
+        login_id: loginId,
+        status: 'ready',
+      },
+    });
+  });
+});

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -1,4 +1,4 @@
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { createHash } from 'node:crypto';
 
 import type { Request, Response } from 'express';
 import z from 'zod';
@@ -40,16 +40,7 @@ function getCodeChallengeFromVerifier(codeVerifier: string) {
 }
 
 function isPkceMatch(codeVerifier: string, codeChallenge: string) {
-  const expectedCodeChallenge = Buffer.from(
-    getCodeChallengeFromVerifier(codeVerifier)
-  );
-  const givenCodeChallenge = Buffer.from(codeChallenge);
-
-  if (expectedCodeChallenge.length !== givenCodeChallenge.length) {
-    return false;
-  }
-
-  return timingSafeEqual(expectedCodeChallenge, givenCodeChallenge);
+  return getCodeChallengeFromVerifier(codeVerifier) === codeChallenge;
 }
 
 function getErrorRenderProps(loginId: string, error: ApiError): RenderProps {

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -13,7 +13,6 @@ import {
   getByAuthorizationCode,
   markLoginReady,
 } from './amsapp-auth-store.ts';
-import { IS_PRODUCTION } from '../../../../universal/config/env.ts';
 import { apiSuccessResult } from '../../../../universal/helpers/api.ts';
 import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
 import {
@@ -23,7 +22,6 @@ import {
 import { getAuth } from '../../../auth/auth-helpers.ts';
 import { authRoutes } from '../../../auth/auth-routes.ts';
 import { ONE_SECOND_MS } from '../../../config/app.ts';
-import { logger } from '../../../logging.ts';
 import { handleServicesAll } from '../../../routing/app-router-protected.ts';
 import {
   generateFullApiUrlBFF,
@@ -83,11 +81,6 @@ export async function handleAmsAppAuthCallback(
   res: Response
 ) {
   const auth = getAuth(req);
-  if (!IS_PRODUCTION) {
-    logger.info(
-      `AmsApp auth callback received for loginId=${req.params.loginId}`
-    );
-  }
 
   if (!auth || auth.profile.profileType !== 'private') {
     return res.render(
@@ -115,12 +108,6 @@ export async function handleAmsAppAuthCallback(
     promptOpenApp: false,
   };
 
-  if (!IS_PRODUCTION) {
-    logger.info(
-      `AmsApp auth callback (non-production) for loginId=${record.loginId}, authorizationCode=${record.authorizationCode}`
-    );
-  }
-
   return res.render('amsapp-open-app', renderProps);
 }
 
@@ -129,13 +116,6 @@ export async function handleAmsAppAuthTokenExchange(
   res: Response
 ) {
   const result = tokenExchangeBodySchema.safeParse(req.body);
-  if (!IS_PRODUCTION) {
-    logger.debug(
-      `AmsApp auth token exchange request received with body: ${JSON.stringify(
-        req.body
-      )}`
-    );
-  }
   if (!result.success) {
     return sendBadRequestInvalidInput(res, result.error);
   }

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -27,12 +27,12 @@ import { baseRenderProps } from '../amsapp-service-config.ts';
 import type { ApiError, RenderProps } from '../amsapp-types.ts';
 
 const loginStartQuerySchema = z.object({
-  code_challenge: z.string().min(1),
+  codeChallenge: z.string().min(1),
 });
 
 const tokenExchangeBodySchema = z.object({
-  authorization_code: z.string().min(1),
-  code_verifier: z.string().min(1),
+  authorizationCode: z.string().min(1),
+  codeVerifier: z.string().min(1),
 });
 
 function getCodeChallengeFromVerifier(codeVerifier: string) {
@@ -68,7 +68,7 @@ export async function handleAmsAppAuthLoginStart(req: Request, res: Response) {
     return sendBadRequestInvalidInput(res, result.error);
   }
 
-  const loginId = createLoginAttempt(result.data.code_challenge);
+  const loginId = createLoginAttempt(result.data.codeChallenge);
 
   return res.redirect(
     generateFullApiUrlBFF(authRoutes.AUTH_LOGIN_DIGID, [
@@ -108,7 +108,7 @@ export async function handleAmsAppAuthCallback(
   const renderProps: RenderProps = {
     ...baseRenderProps,
     identifier: record.loginId,
-    appHref: `${AMSAPP_AUTH_DEEP_LINK_BASE}/gelukt?authorization_code=${record.authorizationCode}`,
+    appHref: `${AMSAPP_AUTH_DEEP_LINK_BASE}/gelukt?authorizationCode=${record.authorizationCode}`,
     promptOpenApp: false,
   };
 
@@ -124,20 +124,20 @@ export async function handleAmsAppAuthTokenExchange(
     return sendBadRequestInvalidInput(res, result.error);
   }
 
-  const record = getByAuthorizationCode(result.data.authorization_code);
+  const record = getByAuthorizationCode(result.data.authorizationCode);
   if (!record || record.status !== 'ready') {
-    return sendBadRequest(res, 'Unknown or invalid authorization_code');
+    return sendBadRequest(res, 'Unknown or invalid authorizationCode');
   }
 
-  if (!isPkceMatch(result.data.code_verifier, record.codeChallenge)) {
-    return sendBadRequest(res, 'Invalid code_verifier for authorization_code');
+  if (!isPkceMatch(result.data.codeVerifier, record.codeChallenge)) {
+    return sendBadRequest(res, 'Invalid codeVerifier for authorizationCode');
   }
 
   const consumedRecord = consumeByAuthorizationCode(
-    result.data.authorization_code
+    result.data.authorizationCode
   );
   if (!consumedRecord?.maSessionCookieValue) {
-    return sendBadRequest(res, 'Unknown or invalid authorization_code');
+    return sendBadRequest(res, 'Unknown or invalid authorizationCode');
   }
 
   return res.send(

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -16,9 +16,13 @@ import {
 import { IS_PRODUCTION } from '../../../../universal/config/env.ts';
 import { apiSuccessResult } from '../../../../universal/helpers/api.ts';
 import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
-import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
+import {
+  OIDC_SESSION_COOKIE_NAME,
+  OIDC_SESSION_MAX_AGE_SECONDS,
+} from '../../../auth/auth-config.ts';
 import { getAuth } from '../../../auth/auth-helpers.ts';
 import { authRoutes } from '../../../auth/auth-routes.ts';
+import { ONE_SECOND_MS } from '../../../config/app.ts';
 import { logger } from '../../../logging.ts';
 import { handleServicesAll } from '../../../routing/app-router-protected.ts';
 import {
@@ -157,6 +161,7 @@ export async function handleAmsAppAuthTokenExchange(
       session: {
         name: OIDC_SESSION_COOKIE_NAME,
         value: consumedRecord.maSessionCookieValue,
+        expiresAt: Date.now() + OIDC_SESSION_MAX_AGE_SECONDS * ONE_SECOND_MS,
       },
     })
   );

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -20,7 +20,6 @@ import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
 import { getAuth } from '../../../auth/auth-helpers.ts';
 import { authRoutes } from '../../../auth/auth-routes.ts';
 import { logger } from '../../../logging.ts';
-import { ensureDevelopmentAuthContext } from '../../../routing/app-router-development.ts';
 import { handleServicesAll } from '../../../routing/app-router-protected.ts';
 import {
   generateFullApiUrlBFF,
@@ -168,8 +167,5 @@ export async function handleAmsAppAuthServicesAllProxy(
   res: Response,
   next: NextFunction
 ) {
-  if (!IS_PRODUCTION) {
-    await ensureDevelopmentAuthContext(req);
-  }
   return handleServicesAll(req, res, next);
 }

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -1,3 +1,5 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
 import type { Request, Response } from 'express';
 import z from 'zod';
 
@@ -6,12 +8,14 @@ import {
   apiResponseErrors,
 } from './amsapp-auth-service-config.ts';
 import {
+  consumeByAuthorizationCode,
   createLoginAttempt,
   getByAuthorizationCode,
   markLoginReady,
 } from './amsapp-auth-store.ts';
 import { apiSuccessResult } from '../../../../universal/helpers/api.ts';
 import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
+import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
 import { getAuth } from '../../../auth/auth-helpers.ts';
 import { authRoutes } from '../../../auth/auth-routes.ts';
 import {
@@ -28,7 +32,25 @@ const loginStartQuerySchema = z.object({
 
 const tokenExchangeBodySchema = z.object({
   authorization_code: z.string().min(1),
+  code_verifier: z.string().min(1),
 });
+
+function getCodeChallengeFromVerifier(codeVerifier: string) {
+  return createHash('sha256').update(codeVerifier).digest('base64url');
+}
+
+function isPkceMatch(codeVerifier: string, codeChallenge: string) {
+  const expectedCodeChallenge = Buffer.from(
+    getCodeChallengeFromVerifier(codeVerifier)
+  );
+  const givenCodeChallenge = Buffer.from(codeChallenge);
+
+  if (expectedCodeChallenge.length !== givenCodeChallenge.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedCodeChallenge, givenCodeChallenge);
+}
 
 function getErrorRenderProps(loginId: string, error: ApiError): RenderProps {
   return {
@@ -71,7 +93,8 @@ export async function handleAmsAppAuthCallback(
     );
   }
 
-  const record = markLoginReady(req.params.loginId);
+  const maSessionCookieValue = req.cookies?.[OIDC_SESSION_COOKIE_NAME] ?? '';
+  const record = markLoginReady(req.params.loginId, maSessionCookieValue);
   if (!record?.authorizationCode) {
     return res.render(
       'amsapp-open-app',
@@ -106,10 +129,23 @@ export async function handleAmsAppAuthTokenExchange(
     return sendBadRequest(res, 'Unknown or invalid authorization_code');
   }
 
+  if (!isPkceMatch(result.data.code_verifier, record.codeChallenge)) {
+    return sendBadRequest(res, 'Invalid code_verifier for authorization_code');
+  }
+
+  const consumedRecord = consumeByAuthorizationCode(
+    result.data.authorization_code
+  );
+  if (!consumedRecord?.maSessionCookieValue) {
+    return sendBadRequest(res, 'Unknown or invalid authorization_code');
+  }
+
   return res.send(
     apiSuccessResult({
-      login_id: record.loginId,
-      status: record.status,
+      session: {
+        name: OIDC_SESSION_COOKIE_NAME,
+        value: consumedRecord.maSessionCookieValue,
+      },
     })
   );
 }

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -19,9 +19,8 @@ import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect
 import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
 import { getAuth } from '../../../auth/auth-helpers.ts';
 import { authRoutes } from '../../../auth/auth-routes.ts';
-import type { AuthProfile } from '../../../auth/auth-types.ts';
 import { logger } from '../../../logging.ts';
-import { createOIDCStub } from '../../../routing/app-router-development.ts';
+import { ensureDevelopmentAuthContext } from '../../../routing/app-router-development.ts';
 import { handleServicesAll } from '../../../routing/app-router-protected.ts';
 import {
   generateFullApiUrlBFF,
@@ -46,46 +45,6 @@ function getCodeChallengeFromVerifier(codeVerifier: string) {
 
 function isPkceMatch(codeVerifier: string, codeChallenge: string) {
   return getCodeChallengeFromVerifier(codeVerifier) === codeChallenge;
-}
-
-function parseDevelopmentSessionCookie(sessionCookieValue: string) {
-  try {
-    const parsed = JSON.parse(
-      Buffer.from(sessionCookieValue, 'base64').toString('ascii')
-    ) as AuthProfile;
-
-    if (
-      parsed &&
-      typeof parsed.id === 'string' &&
-      typeof parsed.sid === 'string' &&
-      (parsed.authMethod === 'digid' || parsed.authMethod === 'eherkenning') &&
-      (parsed.profileType === 'private' || parsed.profileType === 'commercial')
-    ) {
-      return parsed;
-    }
-  } catch {
-    // Ignore parsing errors; this cookie format only exists in local development.
-  }
-
-  return null;
-}
-
-async function ensureDevelopmentAuthContext(req: Request) {
-  if (IS_PRODUCTION || getAuth(req)) {
-    return;
-  }
-
-  const sessionCookieValue = req.cookies?.[OIDC_SESSION_COOKIE_NAME] ?? '';
-  if (!sessionCookieValue) {
-    return;
-  }
-
-  const authProfile = parseDevelopmentSessionCookie(sessionCookieValue);
-  if (!authProfile) {
-    return;
-  }
-
-  await createOIDCStub(req, authProfile);
 }
 
 function getErrorRenderProps(loginId: string, error: ApiError): RenderProps {
@@ -209,6 +168,8 @@ export async function handleAmsAppAuthServicesAllProxy(
   res: Response,
   next: NextFunction
 ) {
-  await ensureDevelopmentAuthContext(req);
+  if (!IS_PRODUCTION) {
+    await ensureDevelopmentAuthContext(req);
+  }
   return handleServicesAll(req, res, next);
 }

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import z from 'zod';
 
 import {
@@ -19,7 +19,10 @@ import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect
 import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
 import { getAuth } from '../../../auth/auth-helpers.ts';
 import { authRoutes } from '../../../auth/auth-routes.ts';
+import type { AuthProfile } from '../../../auth/auth-types.ts';
 import { logger } from '../../../logging.ts';
+import { createOIDCStub } from '../../../routing/app-router-development.ts';
+import { handleServicesAll } from '../../../routing/app-router-protected.ts';
 import {
   generateFullApiUrlBFF,
   sendBadRequest,
@@ -43,6 +46,46 @@ function getCodeChallengeFromVerifier(codeVerifier: string) {
 
 function isPkceMatch(codeVerifier: string, codeChallenge: string) {
   return getCodeChallengeFromVerifier(codeVerifier) === codeChallenge;
+}
+
+function parseDevelopmentSessionCookie(sessionCookieValue: string) {
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(sessionCookieValue, 'base64').toString('ascii')
+    ) as AuthProfile;
+
+    if (
+      parsed &&
+      typeof parsed.id === 'string' &&
+      typeof parsed.sid === 'string' &&
+      (parsed.authMethod === 'digid' || parsed.authMethod === 'eherkenning') &&
+      (parsed.profileType === 'private' || parsed.profileType === 'commercial')
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Ignore parsing errors; this cookie format only exists in local development.
+  }
+
+  return null;
+}
+
+async function ensureDevelopmentAuthContext(req: Request) {
+  if (IS_PRODUCTION || getAuth(req)) {
+    return;
+  }
+
+  const sessionCookieValue = req.cookies?.[OIDC_SESSION_COOKIE_NAME] ?? '';
+  if (!sessionCookieValue) {
+    return;
+  }
+
+  const authProfile = parseDevelopmentSessionCookie(sessionCookieValue);
+  if (!authProfile) {
+    return;
+  }
+
+  await createOIDCStub(req, authProfile);
 }
 
 function getErrorRenderProps(loginId: string, error: ApiError): RenderProps {
@@ -159,4 +202,13 @@ export async function handleAmsAppAuthTokenExchange(
       },
     })
   );
+}
+
+export async function handleAmsAppAuthServicesAllProxy(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  await ensureDevelopmentAuthContext(req);
+  return handleServicesAll(req, res, next);
 }

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -13,11 +13,13 @@ import {
   getByAuthorizationCode,
   markLoginReady,
 } from './amsapp-auth-store.ts';
+import { IS_PRODUCTION } from '../../../../universal/config/env.ts';
 import { apiSuccessResult } from '../../../../universal/helpers/api.ts';
 import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
 import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
 import { getAuth } from '../../../auth/auth-helpers.ts';
 import { authRoutes } from '../../../auth/auth-routes.ts';
+import { logger } from '../../../logging.ts';
 import {
   generateFullApiUrlBFF,
   sendBadRequest,
@@ -76,6 +78,11 @@ export async function handleAmsAppAuthCallback(
   res: Response
 ) {
   const auth = getAuth(req);
+  if (!IS_PRODUCTION) {
+    logger.info(
+      `AmsApp auth callback received for loginId=${req.params.loginId}`
+    );
+  }
 
   if (!auth || auth.profile.profileType !== 'private') {
     return res.render(
@@ -103,6 +110,12 @@ export async function handleAmsAppAuthCallback(
     promptOpenApp: false,
   };
 
+  if (!IS_PRODUCTION) {
+    logger.info(
+      `AmsApp auth callback (non-production) for loginId=${record.loginId}, authorizationCode=${record.authorizationCode}`
+    );
+  }
+
   return res.render('amsapp-open-app', renderProps);
 }
 
@@ -111,6 +124,13 @@ export async function handleAmsAppAuthTokenExchange(
   res: Response
 ) {
   const result = tokenExchangeBodySchema.safeParse(req.body);
+  if (!IS_PRODUCTION) {
+    logger.debug(
+      `AmsApp auth token exchange request received with body: ${JSON.stringify(
+        req.body
+      )}`
+    );
+  }
   if (!result.success) {
     return sendBadRequestInvalidInput(res, result.error);
   }

--- a/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-route-handlers.ts
@@ -1,0 +1,115 @@
+import type { Request, Response } from 'express';
+import z from 'zod';
+
+import {
+  AMSAPP_AUTH_DEEP_LINK_BASE,
+  apiResponseErrors,
+} from './amsapp-auth-service-config.ts';
+import {
+  createLoginAttempt,
+  getByAuthorizationCode,
+  markLoginReady,
+} from './amsapp-auth-store.ts';
+import { apiSuccessResult } from '../../../../universal/helpers/api.ts';
+import { RETURNTO_AMSAPP_AUTH_CALLBACK } from '../../../auth/auth-after-redirect-returnto.ts';
+import { getAuth } from '../../../auth/auth-helpers.ts';
+import { authRoutes } from '../../../auth/auth-routes.ts';
+import {
+  generateFullApiUrlBFF,
+  sendBadRequest,
+  sendBadRequestInvalidInput,
+} from '../../../routing/route-helpers.ts';
+import { baseRenderProps } from '../amsapp-service-config.ts';
+import type { ApiError, RenderProps } from '../amsapp-types.ts';
+
+const loginStartQuerySchema = z.object({
+  code_challenge: z.string().min(1),
+});
+
+const tokenExchangeBodySchema = z.object({
+  authorization_code: z.string().min(1),
+});
+
+function getErrorRenderProps(loginId: string, error: ApiError): RenderProps {
+  return {
+    ...baseRenderProps,
+    error,
+    identifier: loginId,
+    appHref: `${AMSAPP_AUTH_DEEP_LINK_BASE}/mislukt?errorMessage=${encodeURIComponent(error.message)}&errorCode=${error.code}`,
+    promptOpenApp: error.code === apiResponseErrors.DIGID_AUTH.code,
+  };
+}
+
+export async function handleAmsAppAuthLoginStart(req: Request, res: Response) {
+  const result = loginStartQuerySchema.safeParse(req.query);
+  if (!result.success) {
+    return sendBadRequestInvalidInput(res, result.error);
+  }
+
+  const loginId = createLoginAttempt(result.data.code_challenge);
+
+  return res.redirect(
+    generateFullApiUrlBFF(authRoutes.AUTH_LOGIN_DIGID, [
+      {
+        returnTo: RETURNTO_AMSAPP_AUTH_CALLBACK,
+        'amsapp-login-id': loginId,
+      },
+    ])
+  );
+}
+
+export async function handleAmsAppAuthCallback(
+  req: Request<{ loginId: string }>,
+  res: Response
+) {
+  const auth = getAuth(req);
+
+  if (!auth || auth.profile.profileType !== 'private') {
+    return res.render(
+      'amsapp-open-app',
+      getErrorRenderProps(req.params.loginId, apiResponseErrors.DIGID_AUTH)
+    );
+  }
+
+  const record = markLoginReady(req.params.loginId);
+  if (!record?.authorizationCode) {
+    return res.render(
+      'amsapp-open-app',
+      getErrorRenderProps(
+        req.params.loginId,
+        apiResponseErrors.LOGIN_NOT_FOUND_OR_EXPIRED
+      )
+    );
+  }
+
+  const renderProps: RenderProps = {
+    ...baseRenderProps,
+    identifier: record.loginId,
+    appHref: `${AMSAPP_AUTH_DEEP_LINK_BASE}/gelukt?authorization_code=${record.authorizationCode}`,
+    promptOpenApp: false,
+  };
+
+  return res.render('amsapp-open-app', renderProps);
+}
+
+export async function handleAmsAppAuthTokenExchange(
+  req: Request,
+  res: Response
+) {
+  const result = tokenExchangeBodySchema.safeParse(req.body);
+  if (!result.success) {
+    return sendBadRequestInvalidInput(res, result.error);
+  }
+
+  const record = getByAuthorizationCode(result.data.authorization_code);
+  if (!record || record.status !== 'ready') {
+    return sendBadRequest(res, 'Unknown or invalid authorization_code');
+  }
+
+  return res.send(
+    apiSuccessResult({
+      login_id: record.loginId,
+      status: record.status,
+    })
+  );
+}

--- a/src/server/services/amsapp/auth/amsapp-auth-router.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-router.ts
@@ -1,6 +1,7 @@
 import {
   handleAmsAppAuthCallback,
   handleAmsAppAuthLoginStart,
+  handleAmsAppAuthServicesAllProxy,
   handleAmsAppAuthTokenExchange,
 } from './amsapp-auth-route-handlers.ts';
 import { routes } from './amsapp-auth-service-config.ts';
@@ -22,6 +23,12 @@ routerPrivate.post(
   routes.private.AMSAPP_AUTH_TOKEN,
   apiKeyVerificationHandler,
   handleAmsAppAuthTokenExchange
+);
+
+routerPrivate.get(
+  routes.private.AMSAPP_AUTH_SERVICES_ALL,
+  apiKeyVerificationHandler,
+  handleAmsAppAuthServicesAllProxy
 );
 
 export const amsappAuthRouter = {

--- a/src/server/services/amsapp/auth/amsapp-auth-router.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-router.ts
@@ -1,0 +1,30 @@
+import {
+  handleAmsAppAuthCallback,
+  handleAmsAppAuthLoginStart,
+  handleAmsAppAuthTokenExchange,
+} from './amsapp-auth-route-handlers.ts';
+import { routes } from './amsapp-auth-service-config.ts';
+import { apiKeyVerificationHandler } from '../../../routing/route-handlers.ts';
+import { createBFFRouter } from '../../../routing/route-helpers.ts';
+
+const routerPublic = createBFFRouter({
+  id: 'external-consumer-public-amsapp-auth',
+});
+
+routerPublic.get(routes.public.AMSAPP_AUTH_LOGIN, handleAmsAppAuthLoginStart);
+routerPublic.get(routes.public.AMSAPP_AUTH_CALLBACK, handleAmsAppAuthCallback);
+
+const routerPrivate = createBFFRouter({
+  id: 'external-consumer-private-amsapp-auth',
+});
+
+routerPrivate.post(
+  routes.private.AMSAPP_AUTH_TOKEN,
+  apiKeyVerificationHandler,
+  handleAmsAppAuthTokenExchange
+);
+
+export const amsappAuthRouter = {
+  public: routerPublic,
+  private: routerPrivate,
+};

--- a/src/server/services/amsapp/auth/amsapp-auth-router.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-router.ts
@@ -4,12 +4,13 @@ import {
   handleAmsAppAuthServicesAllProxy,
   handleAmsAppAuthTokenExchange,
 } from './amsapp-auth-route-handlers.ts';
-import { routes } from './amsapp-auth-service-config.ts';
+import { featureToggle, routes } from './amsapp-auth-service-config.ts';
 import { apiKeyVerificationHandler } from '../../../routing/route-handlers.ts';
 import { createBFFRouter } from '../../../routing/route-helpers.ts';
 
 const routerPublic = createBFFRouter({
   id: 'external-consumer-public-amsapp-auth',
+  isEnabled: featureToggle.amsAppUniversalAuthIsActive,
 });
 
 routerPublic.get(routes.public.AMSAPP_AUTH_LOGIN, handleAmsAppAuthLoginStart);
@@ -17,6 +18,7 @@ routerPublic.get(routes.public.AMSAPP_AUTH_CALLBACK, handleAmsAppAuthCallback);
 
 const routerPrivate = createBFFRouter({
   id: 'external-consumer-private-amsapp-auth',
+  isEnabled: featureToggle.amsAppUniversalAuthIsActive,
 });
 
 routerPrivate.post(
@@ -25,11 +27,13 @@ routerPrivate.post(
   handleAmsAppAuthTokenExchange
 );
 
-routerPrivate.get(
-  routes.private.AMSAPP_AUTH_SERVICES_ALL,
-  apiKeyVerificationHandler,
-  handleAmsAppAuthServicesAllProxy
-);
+if (featureToggle.amsAppUniversalAuthServicesAllAccessIsActive) {
+  routerPrivate.get(
+    routes.private.AMSAPP_AUTH_SERVICES_ALL,
+    apiKeyVerificationHandler,
+    handleAmsAppAuthServicesAllProxy
+  );
+}
 
 export const amsappAuthRouter = {
   public: routerPublic,

--- a/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
@@ -1,0 +1,23 @@
+import { AMSAPP_BASE_PATH } from '../amsapp-constants.ts';
+
+export const routes = {
+  public: {
+    AMSAPP_AUTH_LOGIN: `${AMSAPP_BASE_PATH}/auth/login`,
+    AMSAPP_AUTH_CALLBACK: `${AMSAPP_BASE_PATH}/auth/callback/:loginId`,
+  },
+  private: {
+    AMSAPP_AUTH_TOKEN: `${AMSAPP_BASE_PATH}/auth/token`,
+  },
+} as const;
+
+export const apiResponseErrors = {
+  DIGID_AUTH: { code: '001', message: 'Niet ingelogd met Digid' },
+  LOGIN_NOT_FOUND_OR_EXPIRED: {
+    code: '002',
+    message: 'Inlogsessie niet gevonden of verlopen',
+  },
+} as const;
+
+export const AMSAPP_AUTH_DEEP_LINK_BASE = 'amsterdam://mijn-amsterdam';
+
+export const AUTHORIZATION_CODE_TTL_MS = 2 * 60 * 1000;

--- a/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
@@ -1,3 +1,4 @@
+import { IS_PRODUCTION } from '../../../../universal/config/env.ts';
 import { isEnabled } from '../../../config/azure-appconfiguration.ts';
 import { AMSAPP_BASE_PATH } from '../amsapp-constants.ts';
 
@@ -29,4 +30,8 @@ export const apiResponseErrors = {
 
 export const AMSAPP_AUTH_DEEP_LINK_BASE = 'amsterdam://mijn-amsterdam';
 
-export const AUTHORIZATION_CODE_TTL_MS = 20 * 60 * 1000;
+const twentyMinutesInMs = 20 * 60 * 1000;
+const twoMinutesInMs = 2 * 60 * 1000;
+export const AUTHORIZATION_CODE_TTL_MS = IS_PRODUCTION
+  ? twoMinutesInMs
+  : twentyMinutesInMs; // In non-production environments, we set a longer TTL for easier testing.

--- a/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
@@ -7,6 +7,7 @@ export const routes = {
   },
   private: {
     AMSAPP_AUTH_TOKEN: `${AMSAPP_BASE_PATH}/auth/token`,
+    AMSAPP_AUTH_SERVICES_ALL: `${AMSAPP_BASE_PATH}/auth/services/all`,
   },
 } as const;
 

--- a/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
@@ -1,4 +1,12 @@
+import { isEnabled } from '../../../config/azure-appconfiguration.ts';
 import { AMSAPP_BASE_PATH } from '../amsapp-constants.ts';
+
+export const featureToggle = {
+  amsAppUniversalAuthIsActive: isEnabled('AMSAPP.universalAuth'),
+  amsAppUniversalAuthServicesAllAccessIsActive:
+    isEnabled('AMSAPP.universalAuth') &&
+    isEnabled('AMSAPP.universalAuth.servicesAllAccess'),
+} as const;
 
 export const routes = {
   public: {

--- a/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-service-config.ts
@@ -20,4 +20,4 @@ export const apiResponseErrors = {
 
 export const AMSAPP_AUTH_DEEP_LINK_BASE = 'amsterdam://mijn-amsterdam';
 
-export const AUTHORIZATION_CODE_TTL_MS = 2 * 60 * 1000;
+export const AUTHORIZATION_CODE_TTL_MS = 20 * 60 * 1000;

--- a/src/server/services/amsapp/auth/amsapp-auth-store.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-store.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+
+import { AUTHORIZATION_CODE_TTL_MS } from './amsapp-auth-service-config.ts';
+
+export type AuthorizationCodeStatus = 'pending' | 'ready' | 'expired';
+
+export type AuthorizationCodeRecord = {
+  loginId: string;
+  status: AuthorizationCodeStatus;
+  codeChallenge: string;
+  authorizationCode: string | null;
+  createdAtMs: number;
+  expiresAtMs: number;
+};
+
+const authorizationCodeStore = new Map<string, AuthorizationCodeRecord>();
+
+function isExpired(record: AuthorizationCodeRecord) {
+  return Date.now() > record.expiresAtMs;
+}
+
+function getRecord(loginId: string) {
+  const record = authorizationCodeStore.get(loginId) ?? null;
+  if (!record) {
+    return null;
+  }
+
+  if (isExpired(record)) {
+    record.status = 'expired';
+    record.authorizationCode = null;
+  }
+
+  return record;
+}
+
+export function createLoginAttempt(codeChallenge: string) {
+  const loginId = randomUUID();
+  const createdAtMs = Date.now();
+
+  authorizationCodeStore.set(loginId, {
+    loginId,
+    status: 'pending',
+    codeChallenge,
+    authorizationCode: null,
+    createdAtMs,
+    expiresAtMs: createdAtMs + AUTHORIZATION_CODE_TTL_MS,
+  });
+
+  return loginId;
+}
+
+export function markLoginReady(loginId: string) {
+  const record = getRecord(loginId);
+
+  if (!record || record.status !== 'pending') {
+    return null;
+  }
+
+  record.status = 'ready';
+  record.authorizationCode = randomUUID();
+
+  return record;
+}
+
+export function getByAuthorizationCode(authorizationCode: string) {
+  for (const record of authorizationCodeStore.values()) {
+    if (record.authorizationCode !== authorizationCode) {
+      continue;
+    }
+
+    if (isExpired(record)) {
+      record.status = 'expired';
+      record.authorizationCode = null;
+      return null;
+    }
+
+    return record;
+  }
+
+  return null;
+}
+
+export function getByLoginId(loginId: string) {
+  return getRecord(loginId);
+}
+
+export function clearAmsAppAuthStore() {
+  authorizationCodeStore.clear();
+}

--- a/src/server/services/amsapp/auth/amsapp-auth-store.ts
+++ b/src/server/services/amsapp/auth/amsapp-auth-store.ts
@@ -9,6 +9,7 @@ export type AuthorizationCodeRecord = {
   status: AuthorizationCodeStatus;
   codeChallenge: string;
   authorizationCode: string | null;
+  maSessionCookieValue: string | null;
   createdAtMs: number;
   expiresAtMs: number;
 };
@@ -42,6 +43,7 @@ export function createLoginAttempt(codeChallenge: string) {
     status: 'pending',
     codeChallenge,
     authorizationCode: null,
+    maSessionCookieValue: null,
     createdAtMs,
     expiresAtMs: createdAtMs + AUTHORIZATION_CODE_TTL_MS,
   });
@@ -49,15 +51,16 @@ export function createLoginAttempt(codeChallenge: string) {
   return loginId;
 }
 
-export function markLoginReady(loginId: string) {
+export function markLoginReady(loginId: string, maSessionCookieValue: string) {
   const record = getRecord(loginId);
 
-  if (!record || record.status !== 'pending') {
+  if (!record || record.status !== 'pending' || !maSessionCookieValue) {
     return null;
   }
 
   record.status = 'ready';
   record.authorizationCode = randomUUID();
+  record.maSessionCookieValue = maSessionCookieValue;
 
   return record;
 }
@@ -78,6 +81,16 @@ export function getByAuthorizationCode(authorizationCode: string) {
   }
 
   return null;
+}
+
+export function consumeByAuthorizationCode(authorizationCode: string) {
+  const record = getByAuthorizationCode(authorizationCode);
+  if (!record) {
+    return null;
+  }
+
+  authorizationCodeStore.delete(record.loginId);
+  return record;
 }
 
 export function getByLoginId(loginId: string) {

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-route-handlers.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-route-handlers.ts
@@ -32,10 +32,7 @@ import { captureMessage, captureException } from '../../monitoring.ts';
 import { baseRenderProps } from '../amsapp-service-config.ts';
 import type { ApiError, RenderProps } from '../amsapp-types.ts';
 
-export async function sendAdministratienummerResponse(
-  req: Request,
-  res: Response
-) {
+async function sendAdministratienummerResponse(req: Request, res: Response) {
   await ensureDevelopmentAuthContext(req);
 
   const authProfileAndToken: AuthProfileAndToken | null = getAuth(req);
@@ -259,7 +256,7 @@ export async function sendStadspasBlockRequest(
 }
 
 export const forTesting = {
-  sendAdministratienummerResponse: handleAdministratienummerExchange,
+  handleAdministratienummerExchange,
   sendAdministratienummerEncryptedResponse: sendAdministratienummerResponse,
   sendStadspassenResponse,
   sendDiscountTransactionsResponse,

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-route-handlers.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-route-handlers.ts
@@ -36,9 +36,7 @@ export async function sendAdministratienummerResponse(
   req: Request,
   res: Response
 ) {
-  if (!IS_PRODUCTION) {
-    await ensureDevelopmentAuthContext(req);
-  }
+  await ensureDevelopmentAuthContext(req);
 
   const authProfileAndToken: AuthProfileAndToken | null = getAuth(req);
 

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-route-handlers.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-route-handlers.ts
@@ -11,6 +11,7 @@ import { getAuth } from '../../../auth/auth-helpers.ts';
 import type { AuthProfileAndToken } from '../../../auth/auth-types.ts';
 import { encrypt, decrypt } from '../../../helpers/encrypt-decrypt.ts';
 import { requestData } from '../../../helpers/source-api-request.ts';
+import { ensureDevelopmentAuthContext } from '../../../routing/app-router-development.ts';
 import {
   sendResponse,
   sendBadRequest,
@@ -30,6 +31,56 @@ import {
 import { captureMessage, captureException } from '../../monitoring.ts';
 import { baseRenderProps } from '../amsapp-service-config.ts';
 import type { ApiError, RenderProps } from '../amsapp-types.ts';
+
+export async function sendAdministratienummerResponse(
+  req: Request,
+  res: Response
+) {
+  if (!IS_PRODUCTION) {
+    await ensureDevelopmentAuthContext(req);
+  }
+
+  const authProfileAndToken: AuthProfileAndToken | null = getAuth(req);
+
+  if (
+    !authProfileAndToken ||
+    !authProfileAndToken.profile.id ||
+    authProfileAndToken.profile.profileType !== 'private'
+  ) {
+    return sendBadRequest(
+      res,
+      `ApiError ${apiResponseErrors.DIGID_AUTH.code} - ${apiResponseErrors.DIGID_AUTH.message}`
+    );
+  }
+
+  const administratienummerResponse = await fetchAdministratienummer(
+    authProfileAndToken.profile.id
+  );
+
+  if (
+    administratienummerResponse.status === 'OK' &&
+    administratienummerResponse.content !== null
+  ) {
+    const [administratienummerEncrypted] = encrypt(
+      administratienummerResponse.content
+    );
+
+    return res.send(
+      apiSuccessResult({
+        administratienummerEncrypted,
+      })
+    );
+  }
+
+  if (!administratienummerResponse.content) {
+    return sendBadRequest(
+      res,
+      `ApiError ${apiResponseErrors.ADMINISTRATIENUMMER_NOT_FOUND.code} - ${apiResponseErrors.ADMINISTRATIENUMMER_NOT_FOUND.message}`
+    );
+  }
+
+  return sendResponse(res, administratienummerResponse);
+}
 
 export async function handleAdministratienummerExchange(
   req: Request<{ token: string }>,
@@ -211,6 +262,7 @@ export async function sendStadspasBlockRequest(
 
 export const forTesting = {
   sendAdministratienummerResponse: handleAdministratienummerExchange,
+  sendAdministratienummerEncryptedResponse: sendAdministratienummerResponse,
   sendStadspassenResponse,
   sendDiscountTransactionsResponse,
   sendBudgetTransactionsResponse,

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-router.test.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-router.test.ts
@@ -10,6 +10,7 @@ import {
   apiErrorResult,
   apiSuccessResult,
 } from '../../../../universal/helpers/api.ts';
+import { OIDC_SESSION_COOKIE_NAME } from '../../../auth/auth-config.ts';
 import type { AuthProfile } from '../../../auth/auth-types.ts';
 import * as gpass from '../../hli/stadspas-gpass-service.ts';
 import type { Stadspas } from '../../hli/stadspas-types.ts';
@@ -181,6 +182,47 @@ describe('hli/router-external-consumer', async () => {
       });
       expect(renderSecondArg.appHref).toStrictEqual(
         'amsterdam://stadspas/mislukt?errorMessage=Niet%20ingelogd%20met%20Digid&errorCode=001'
+      );
+    });
+
+    test('Private encrypted administratienummer endpoint - OK', async () => {
+      remoteApi.post('/zorgned/persoonsgegevensNAW').reply(200, {
+        persoon: {
+          clientidentificatie: '123-123',
+        },
+      });
+
+      const reqMock = RequestMock.new().setCookies({
+        [OIDC_SESSION_COOKIE_NAME]: Buffer.from(
+          JSON.stringify(USER_PROFILE)
+        ).toString('base64'),
+      });
+      const req = reqMock.get();
+      const resMock = ResponseMock.new();
+
+      await forTesting.sendAdministratienummerEncryptedResponse(req, resMock);
+
+      expect(resMock.send).toHaveBeenCalledWith({
+        status: 'OK',
+        content: {
+          administratienummerEncrypted: 'test-encrypted-id',
+        },
+      });
+    });
+
+    test('Private encrypted administratienummer endpoint - unauthorized without cookie', async () => {
+      const req = RequestMock.new().get();
+      const resMock = ResponseMock.new();
+
+      await forTesting.sendAdministratienummerEncryptedResponse(req, resMock);
+
+      expect(resMock.status).toHaveBeenCalledWith(400);
+      expect(resMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'ERROR',
+          message: 'Bad request: ApiError 001 - Niet ingelogd met Digid',
+          code: 400,
+        })
       );
     });
   });

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-router.test.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-router.test.ts
@@ -185,7 +185,7 @@ describe('hli/router-external-consumer', async () => {
       );
     });
 
-    test('Private encrypted administratienummer endpoint - OK', async () => {
+    test('Private encrypted administratienummer endpoint uses session cookie - OK', async () => {
       remoteApi.post('/zorgned/persoonsgegevensNAW').reply(200, {
         persoon: {
           clientidentificatie: '123-123',

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-router.test.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-router.test.ts
@@ -73,7 +73,7 @@ describe('hli/router-external-consumer', async () => {
 
       const resMock = ResponseMock.new();
 
-      await forTesting.sendAdministratienummerResponse(
+      await forTesting.handleAdministratienummerExchange(
         reqMockWithTokenParams,
         resMock
       );
@@ -97,7 +97,7 @@ describe('hli/router-external-consumer', async () => {
         await createAuthenticatedRequestMock<typeof params>(params);
       const resMock = ResponseMock.new();
 
-      await forTesting.sendAdministratienummerResponse(
+      await forTesting.handleAdministratienummerExchange(
         reqMockWithTokenParams,
         resMock
       );
@@ -117,7 +117,7 @@ describe('hli/router-external-consumer', async () => {
       const resMock = ResponseMock.new();
       const reqMock = RequestMock.new().get<typeof params>();
 
-      await forTesting.sendAdministratienummerResponse(reqMock, resMock);
+      await forTesting.handleAdministratienummerExchange(reqMock, resMock);
 
       const renderSecondArg = resMock.render.mock.calls[0][1];
       expect(renderSecondArg.error).toStrictEqual({
@@ -133,7 +133,7 @@ describe('hli/router-external-consumer', async () => {
       remoteApi.post('/zorgned/persoonsgegevensNAW').reply(404);
       const resMock = ResponseMock.new();
 
-      await forTesting.sendAdministratienummerResponse(
+      await forTesting.handleAdministratienummerExchange(
         reqMockWithTokenParams,
         resMock
       );
@@ -152,7 +152,7 @@ describe('hli/router-external-consumer', async () => {
       remoteApi.post('/zorgned/persoonsgegevensNAW').reply(500);
       const resMock = ResponseMock.new();
 
-      await forTesting.sendAdministratienummerResponse(
+      await forTesting.handleAdministratienummerExchange(
         reqMockWithTokenParams,
         resMock
       );
@@ -170,7 +170,7 @@ describe('hli/router-external-consumer', async () => {
     test('Unauthorized', async () => {
       const resMock = ResponseMock.new();
 
-      await forTesting.sendAdministratienummerResponse(
+      await forTesting.handleAdministratienummerExchange(
         RequestMock.new().get(),
         resMock
       );

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-router.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-router.ts
@@ -17,6 +17,7 @@ import {
   createBFFRouter,
   generateFullApiUrlBFF,
 } from '../../../routing/route-helpers.ts';
+import { featureToggle } from '../auth/amsapp-auth-service-config.ts';
 
 // PUBLIC INTERNET NETWORK ROUTER
 // ==============================
@@ -54,11 +55,13 @@ const routerPrivateNetwork = createBFFRouter({
   id: 'external-consumer-private-network-stadspas',
 });
 
-routerPrivateNetwork.get(
-  routes.private.STADSPAS_ADMINISTRATIENUMMER,
-  apiKeyVerificationHandler,
-  sendAdministratienummerResponse
-);
+if (featureToggle.amsAppUniversalAuthIsActive) {
+  routerPrivateNetwork.get(
+    routes.private.STADSPAS_ADMINISTRATIENUMMER,
+    apiKeyVerificationHandler,
+    sendAdministratienummerResponse
+  );
+}
 
 routerPrivateNetwork.get(
   routes.private.STADSPAS_PASSEN,

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-router.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-router.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 
 import {
   handleAdministratienummerExchange,
+  sendAdministratienummerResponse,
   sendAppLandingResponse,
   sendStadspassenResponse,
   sendDiscountTransactionsResponse,
@@ -52,6 +53,12 @@ routerInternet.get(
 const routerPrivateNetwork = createBFFRouter({
   id: 'external-consumer-private-network-stadspas',
 });
+
+routerPrivateNetwork.get(
+  routes.private.STADSPAS_ADMINISTRATIENUMMER,
+  apiKeyVerificationHandler,
+  sendAdministratienummerResponse
+);
 
 routerPrivateNetwork.get(
   routes.private.STADSPAS_PASSEN,

--- a/src/server/services/amsapp/stadspas/amsapp-stadspas-service-config.ts
+++ b/src/server/services/amsapp/stadspas/amsapp-stadspas-service-config.ts
@@ -37,6 +37,7 @@ export const routes = {
   },
   // Privately accessible over private network
   private: {
+    STADSPAS_ADMINISTRATIENUMMER: `${AMSAPP_BASE_PATH}/stadspas/administratienummer`,
     STADSPAS_PASSEN: `${AMSAPP_BASE_PATH}/stadspas/passen/:administratienummerEncrypted`,
     STADSPAS_DISCOUNT_TRANSACTIONS: `${AMSAPP_BASE_PATH}/stadspas/aanbiedingen/transactions/:transactionsKeyEncrypted`,
     STADSPAS_BUDGET_TRANSACTIONS: `${AMSAPP_BASE_PATH}/stadspas/budget/transactions/:transactionsKeyEncrypted`,

--- a/src/server/services/controller.ts
+++ b/src/server/services/controller.ts
@@ -452,7 +452,7 @@ export async function loadServicesSSE(req: Request, res: Response) {
   });
 }
 
-export async function loadServicesAll(req: Request, res: Response) {
+export async function loadServicesAll(req: Request, _res: Response) {
   const authProfileAndToken = getAuth(req);
 
   if (!authProfileAndToken) {

--- a/src/server/views/amsapp-open-app.pug
+++ b/src/server/views/amsapp-open-app.pug
@@ -15,7 +15,7 @@ html(lang="nl")
       h1 Inloggen
       p Open de Amsterdam App om verder te gaan.
 
-      if identifier
+      if showIdentifier && identifier
         pre #{identifier}
 
       if error


### PR DESCRIPTION
Met de amsapp hebben we tijdens een PoC dit gebouwd om de login flow consistent te maken en het mogelijk te maken om nieuwe verbindingen makkelijker op te zetten. Met een login blijft de gebruiker ingelogd zodat meerdere mijnadam services benaderd kunnen worden en de gebruiker niet opnieuw hoeft in te loggen met digid voor elke verbinding (stadspas/notificaties).

Wat vind je van de algemene aanpak? Dan gaan we vervolgens de missende onderdelen oppakken/uitwerken.

Hier mist nog:
- de database persistence laag voor authorisatie codes
- status/errors contract
- update openapi
- logout invalidatie van codes/sessies
- checks zoals concurrency 
- amsapp notificaties werkt met deze inlogmethode

Flow Oauth + PKCE:
1. Gebruiker drukt op inloggen in Aapp.
2. Aapp maakt code_verifier en code_challenge.
3. Aapp opent browser naar publieke BFF login-start met codeChallenge.
4. MamsBFF start DigiD OIDC flow.
5. Gebruiker logt in bij DigiD (browsercontext).
6. OIDC callback komt terug in MamsBFF, record wordt ready, authorizationCode (aangemaakt door ons) wordt uitgegeven.
7. Browser krijgt successpagina met deeplink terug naar app.
8. Aapp ontvangt authorizationCode en roept via app-backend proxy de private token exchange aan. Met authorizationCode en codeVerifier.
9. MamsBFF zoekt codeChallenge aan de hand van authorizationCode. MamsBFF valideert verifier en challenge combinatie, verwijdert db record voor deze flow, retourneert MA sessiewaarde voor digid sessie.
10. Aapp gebruikt die sessiewaarde in vervolgaanroepen; private auth-context middleware zet dit om naar bruikbare backend auth-context.