### PR TITLE
MIJN-13381-BUG: GetElementOnPage timeout not cleared causing async errors in tests

### DIFF
--- a/src/client/helpers/utils.ts
+++ b/src/client/helpers/utils.ts
@@ -19,21 +19,40 @@ const FAIL_TIMEOUT_MS = 1000;
 
 export function getElementOnPageAsync(
   query: string,
-  timeout: number = FAIL_TIMEOUT_MS,
+  timeoutAfterMS: number = FAIL_TIMEOUT_MS,
   interval: number = POLL_INTERVAL_MS
 ): Promise<Element | null> {
-  return new Promise((resolve) => {
-    const startTime = Date.now();
-    function checkIfElementIsInDOM() {
-      const elem = document?.querySelector(query);
-      if (elem) {
-        resolve(elem); // Found the element
-      } else if (Date.now() - startTime > timeout) {
-        resolve(null); // Give up eventually
-      } else {
-        setTimeout(checkIfElementIsInDOM, interval); // check again every interval ms
+  return new Promise((resolve_) => {
+    function resolve(result: Element | null) {
+      if (timeout !== null) {
+        clearTimeout(timeout);
+        timeout = null;
       }
+      return resolve_(result);
     }
-    checkIfElementIsInDOM(); // Initial check
+
+    function checkIfElementIsInDOM() {
+      const doc = globalThis.document;
+      if (!doc) {
+        resolve(null);
+        return;
+      }
+
+      const elem = doc.querySelector(query);
+      if (elem) {
+        return resolve(elem);
+      }
+
+      const timeElapsed = Date.now() - startTime;
+      if (timeElapsed > timeoutAfterMS) {
+        return resolve(null);
+      }
+
+      timeout = setTimeout(checkIfElementIsInDOM, interval);
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const startTime = Date.now();
+    checkIfElementIsInDOM();
   });
 }


### PR DESCRIPTION
Een vervelende async bug die af en toe opspeelt doordat de timeout nog bestaat nadat de test is afgerond. Dit cleared de timeout altijd voordat de functie resolved wordt

Fixes:
```
ReferenceError: document is not defined
 ❯ Timeout.checkIfElementIsInDOM [as _onTimeout] src/client/helpers/utils.ts:28:20
 ❯ listOnTimeout node:internal/timers:605:17
 ❯ processTimers node:internal/timers:541:7

This error originated in "src/client/components/AfspraakCard/AfspraakCard.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
This error was caught after test environment was torn down. Make sure to cancel any running tasks before test finishes:
- cancel timeouts using clearTimeout and clearInterval
- wait for promises to resolve using the await keyword
```