### PR TITLE
MIJN-11574-FEATURE: Fix eslint test errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "rewriteRelativeImportExtensions": true,
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": [
     "src",


### PR DESCRIPTION
Fixes: Property 'toBeInTheDocument' does not exist on type 'Assertion<HTMLElement>'.