### PR TITLE
MIJN-12896-BUG: Tussenruimte tabbellen stadspas

### DIFF
--- a/src/client/pages/Thema/HLI/HLIStadspasDetail.test.tsx
+++ b/src/client/pages/Thema/HLI/HLIStadspasDetail.test.tsx
@@ -321,26 +321,10 @@ describe('With basic request where data returned does not matter', () => {
 
 describe('Displayed description of uw uitgaven text', () => {
   test('Without budget or expenses', () => {
-    const result = forTesting.determineUwUitgavenDescription(
-      createStadspas(),
-      false
-    );
+    const result = forTesting.determineUwUitgavenDescription(createStadspas());
     expect(result).toMatchInlineSnapshot(`
       <React.Fragment>
         U heeft nog geen uitgaven.
-      </React.Fragment>
-    `);
-  });
-
-  test('With transactions', () => {
-    const result = forTesting.determineUwUitgavenDescription(
-      createStadspas(),
-      true
-    );
-
-    expect(result).toMatchInlineSnapshot(`
-      <React.Fragment>
-        Hieronder ziet u bij welke winkels u het tegoed hebt uitgegeven. Deze informatie kan een dag achterlopen. Maar het saldo dat u nog over heeft klopt altijd.
       </React.Fragment>
     `);
   });
@@ -360,8 +344,7 @@ describe('Displayed description of uw uitgaven text', () => {
     };
 
     const result = forTesting.determineUwUitgavenDescription(
-      createStadspas({ budgets: [budget], balance: 5 }),
-      false
+      createStadspas({ budgets: [budget], balance: 5 })
     );
     // prettier-ignore
     expect(result).toMatchInlineSnapshot(`

--- a/src/client/pages/Thema/HLI/HLIStadspasDetail.test.tsx
+++ b/src/client/pages/Thema/HLI/HLIStadspasDetail.test.tsx
@@ -352,9 +352,7 @@ describe('Displayed description of uw uitgaven text', () => {
         <React.Fragment>
           U heeft nog geen uitgaven.
         </React.Fragment>
-        <React.Fragment>
-          Deze informatie kan een dag achterlopen. Maar het saldo dat u nog over heeft klopt altijd.
-        </React.Fragment>
+         Deze informatie kan een dag achterlopen. Maar het saldo dat u nog over heeft klopt altijd.
       </React.Fragment>
     `);
   });

--- a/src/client/pages/Thema/HLI/HLIStadspasDetail.tsx
+++ b/src/client/pages/Thema/HLI/HLIStadspasDetail.tsx
@@ -268,25 +268,14 @@ function addReadMoreLink(budget: StadspasBudget) {
 
 function determineUwUitgavenDescription(
   stadspas: StadspasFrontend | undefined
-) {
+): JSX.Element {
   const expenseInfoTextBase = <>U heeft nog geen uitgaven.</>;
 
-  const extraInfo = (
-    <>
-      Deze informatie kan een dag achterlopen. Maar het saldo dat u nog over
-      heeft klopt altijd.
-    </>
-  );
-
-  if (!stadspas) {
-    return expenseInfoTextBase;
-  }
-
-  if (stadspas.budgets && stadspas.balance > 0) {
+  if (stadspas?.budgets && stadspas?.balance > 0) {
     return (
       <>
-        {expenseInfoTextBase}
-        {extraInfo}
+        {expenseInfoTextBase} Deze informatie kan een dag achterlopen. Maar het
+        saldo dat u nog over heeft klopt altijd.
       </>
     );
   }

--- a/src/client/pages/Thema/HLI/HLIStadspasDetail.tsx
+++ b/src/client/pages/Thema/HLI/HLIStadspasDetail.tsx
@@ -216,15 +216,18 @@ export function HLIStadspasDetail() {
         {(isLoadingTransacties || isLoadingStadspas) && (
           <LoadingContent barConfig={loadingContentBarConfigList} />
         )}
-        {!isLoadingStadspas && !isLoadingTransacties && (
-          <Paragraph>
-            {determineUwUitgavenDescription(stadspas, hasTransactions)}
-          </Paragraph>
+        {!isLoadingStadspas && !isLoadingTransacties && !hasTransactions && (
+          <Paragraph>{determineUwUitgavenDescription(stadspas)}</Paragraph>
         )}
-      </PageContentCell>
-      {!isLoadingTransacties && hasTransactions && (
-        <PageContentCell>
+        {!isLoadingTransacties && hasTransactions && (
           <TableV2<StadspasBudgetTransaction>
+            contentAfterTheCaption={
+              <>
+                Hieronder ziet u bij welke winkels u het tegoed hebt uitgegeven.
+                Deze informatie kan een dag achterlopen. Maar het saldo dat u
+                nog over heeft klopt altijd.
+              </>
+            }
             className={
               showMultiBudgetTransactions
                 ? styles.Table_transactions__withBudget
@@ -237,8 +240,8 @@ export function HLIStadspasDetail() {
                 : displayPropsTransacties
             }
           />
-        </PageContentCell>
-      )}
+        )}
+      </PageContentCell>
     </PageV2>
   );
 }
@@ -264,8 +267,7 @@ function addReadMoreLink(budget: StadspasBudget) {
 }
 
 function determineUwUitgavenDescription(
-  stadspas: StadspasFrontend | undefined,
-  hasTransactions: boolean
+  stadspas: StadspasFrontend | undefined
 ) {
   const expenseInfoTextBase = <>U heeft nog geen uitgaven.</>;
 
@@ -280,15 +282,7 @@ function determineUwUitgavenDescription(
     return expenseInfoTextBase;
   }
 
-  if (hasTransactions) {
-    return (
-      <>
-        Hieronder ziet u bij welke winkels u het tegoed hebt uitgegeven. Deze
-        informatie kan een dag achterlopen. Maar het saldo dat u nog over heeft
-        klopt altijd.
-      </>
-    );
-  } else if (stadspas.budgets && stadspas.balance > 0) {
+  if (stadspas.budgets && stadspas.balance > 0) {
     return (
       <>
         {expenseInfoTextBase}


### PR DESCRIPTION
Witruimten zijn gelijk gemaakt door pagina-elementen op dezelfde manier op te bouwen.  

Ik heb de witruimte tussen contentAfterCaption en de tabel niet vergroot. Dit kan namelijk de opmaak op meerdere pagina’s veranderen.

<img width="1381" height="882" alt="image" src="https://github.com/user-attachments/assets/f7b35b9e-a8d9-4165-a747-dcfbac4bdffd" />
