### PR TITLE
MIJN-11457-FEATURE: Fat afspraken stadsloket derde iteratie

### DIFF
--- a/src/client/assets/icons/afspraak.svg
+++ b/src/client/assets/icons/afspraak.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 5.98C15.6513 5.98 16.99 4.64133 16.99 2.99C16.99 1.33867 15.6513 0 14 0C12.3487 0 11.01 1.33867 11.01 2.99C11.01 4.64133 12.3487 5.98 14 5.98Z" />
+<path d="M20 11.98V10.98C20 7.98 18.3 6.98 16 6.98H12C9.69 6.98 8 7.98 8 10.98V11.98H20Z" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M26 28H24V26H4V28H2V16H0V14H28V16H26V28ZM24 22V18H4V22H24Z" />
+</svg>

--- a/src/client/assets/icons/index.tsx
+++ b/src/client/assets/icons/index.tsx
@@ -10,3 +10,4 @@ export { default as IconConnectorTypeMennekes } from './map/connector-type-menne
 export { default as IconIndeterminate } from './min.svg?react';
 export { default as IconHome } from './home.svg?react';
 export { default as IconWior } from './wior.svg?react';
+export { default as IconAfspraak } from './afspraak.svg?react';

--- a/src/client/components/AfspraakCard/AfspraakCard.test.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.test.tsx
@@ -16,6 +16,7 @@ const afspraak: AfspraakFrontend = {
       name: 'Varen',
     },
   ],
+  heading: 'Varen Afspraak',
   dateStart: '2020-01-17T17:50:00Z',
   dateEnd: '2020-01-17T18:20:00Z',
   dateStartFormatted: 'maandag 01 januari 2025',
@@ -85,29 +86,11 @@ describe('Renders afspraak data', () => {
     expect(screen.asFragment()).toMatchSnapshot();
   });
 
-  it('Displays the subject as heading for a single product', () => {
+  it('Displays the heading', () => {
     const screen = renderAfspraakCard(afspraak);
 
     expect(
-      screen.getByRole('heading', { name: afspraak.subject })
-    ).toBeInTheDocument();
-  });
-
-  it('Displays three products as a Dutch heading list', () => {
-    const afspraakWithThreeProducts: AfspraakFrontend = {
-      ...afspraak,
-      subject: 'Niet zichtbaar als heading',
-      products: [
-        { name: 'Product A' },
-        { name: 'Product B' },
-        { name: 'Product C' },
-      ],
-    };
-
-    const screen = renderAfspraakCard(afspraakWithThreeProducts);
-
-    expect(
-      screen.getByRole('heading', { name: 'Product A, Product B en Product C' })
+      screen.getByRole('heading', { name: afspraak.heading })
     ).toBeInTheDocument();
   });
 

--- a/src/client/components/AfspraakCard/AfspraakCard.test.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.test.tsx
@@ -75,7 +75,7 @@ describe('Renders afspraak data', () => {
     expect(screen.asFragment()).toMatchSnapshot();
   });
 
-  test('Compact variant', () => {
+  test('Dashboard variant', () => {
     const screen = renderAfspraakCard(afspraak, true);
     expect(screen.asFragment()).toMatchSnapshot();
   });

--- a/src/client/components/AfspraakCard/AfspraakCard.test.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.test.tsx
@@ -11,6 +11,11 @@ const address = { street: 'Amstel', houseNumber: 1 };
 
 const afspraak: AfspraakFrontend = {
   subject: 'Varen',
+  products: [
+    {
+      name: 'Varen',
+    },
+  ],
   dateStart: '2020-01-17T17:50:00Z',
   dateEnd: '2020-01-17T18:20:00Z',
   dateStartFormatted: 'maandag 01 januari 2025',

--- a/src/client/components/AfspraakCard/AfspraakCard.test.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.test.tsx
@@ -10,12 +10,6 @@ import type { AfspraakFrontend } from '../../../server/services/klantcontact/kla
 const address = { street: 'Amstel', houseNumber: 1 };
 
 const afspraak: AfspraakFrontend = {
-  subject: 'Varen',
-  products: [
-    {
-      name: 'Varen',
-    },
-  ],
   heading: 'Varen Afspraak',
   dateStart: '2020-01-17T17:50:00Z',
   dateEnd: '2020-01-17T18:20:00Z',
@@ -46,10 +40,10 @@ const afspraak: AfspraakFrontend = {
 
 function renderAfspraakCard(
   afspraak: AfspraakFrontend,
-  compact: boolean = false
+  dashboard: boolean = false
 ) {
   return render(
-    <AfspraakCard afspraak={afspraak} compact={compact}></AfspraakCard>,
+    <AfspraakCard afspraak={afspraak} dashboard={dashboard}></AfspraakCard>,
     {
       wrapper: BrowserRouter,
     }

--- a/src/client/components/AfspraakCard/AfspraakCard.test.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.test.tsx
@@ -117,6 +117,7 @@ describe('Renders afspraak data', () => {
     const button = screen.getByRole('button', {
       name: /Toon QR code/i,
     });
+
     await user.click(button);
     expect(
       screen.getByText(/QR code - Stadsloket Centrum/i)
@@ -128,7 +129,7 @@ describe('Renders afspraak data', () => {
     const screen = renderAfspraakCard(afspraak);
     const user = userEvent.setup();
     const button = screen.getByRole('button', {
-      name: /Toon op kaart/i,
+      name: /Stadsloket Centrum, Amstel 1/i,
     });
     await user.click(button);
     expect(
@@ -146,9 +147,8 @@ describe('Renders afspraak data', () => {
     };
     const screen = renderAfspraakCard(afspraakWithoutStreet);
     const button = screen.queryByRole('button', {
-      name: /Toon op kaart/i,
+      name: /Stadsloket Centrum, Amstel 1/i,
     });
     expect(button).not.toBeInTheDocument();
-    expect(screen.getByText(`Locatie: Stadsloket Centrum`)).toBeInTheDocument();
   });
 });

--- a/src/client/components/AfspraakCard/AfspraakCard.test.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.test.tsx
@@ -85,6 +85,32 @@ describe('Renders afspraak data', () => {
     expect(screen.asFragment()).toMatchSnapshot();
   });
 
+  it('Displays the subject as heading for a single product', () => {
+    const screen = renderAfspraakCard(afspraak);
+
+    expect(
+      screen.getByRole('heading', { name: afspraak.subject })
+    ).toBeInTheDocument();
+  });
+
+  it('Displays three products as a Dutch heading list', () => {
+    const afspraakWithThreeProducts: AfspraakFrontend = {
+      ...afspraak,
+      subject: 'Niet zichtbaar als heading',
+      products: [
+        { name: 'Product A' },
+        { name: 'Product B' },
+        { name: 'Product C' },
+      ],
+    };
+
+    const screen = renderAfspraakCard(afspraakWithThreeProducts);
+
+    expect(
+      screen.getByRole('heading', { name: 'Product A, Product B en Product C' })
+    ).toBeInTheDocument();
+  });
+
   test('Opens QR code modal', async () => {
     const screen = renderAfspraakCard(afspraak);
     const user = userEvent.setup();

--- a/src/client/components/AfspraakCard/AfspraakCard.test.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.test.tsx
@@ -4,7 +4,7 @@ import mockdate from 'mockdate';
 import nock from 'nock';
 import { BrowserRouter } from 'react-router';
 
-import { AfspraakCard } from './AfspraakCard.tsx';
+import { AfspraakCard, AfspraakCardDashboard } from './AfspraakCard.tsx';
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
 
 const address = { street: 'Amstel', houseNumber: 1 };
@@ -38,16 +38,15 @@ const afspraak: AfspraakFrontend = {
   },
 };
 
-function renderAfspraakCard(
-  afspraak: AfspraakFrontend,
-  dashboard: boolean = false
-) {
-  return render(
-    <AfspraakCard afspraak={afspraak} dashboard={dashboard}></AfspraakCard>,
-    {
-      wrapper: BrowserRouter,
-    }
-  );
+function renderAfspraakCard(afspraak: AfspraakFrontend) {
+  return render(<AfspraakCard afspraak={afspraak} />, {
+    wrapper: BrowserRouter,
+  });
+}
+function renderAfspraakCardDashboard(afspraak: AfspraakFrontend) {
+  return render(<AfspraakCardDashboard afspraak={afspraak} />, {
+    wrapper: BrowserRouter,
+  });
 }
 
 function setupNockForLocationModal() {
@@ -76,7 +75,7 @@ describe('Renders afspraak data', () => {
   });
 
   test('Dashboard variant', () => {
-    const screen = renderAfspraakCard(afspraak, true);
+    const screen = renderAfspraakCardDashboard(afspraak);
     expect(screen.asFragment()).toMatchSnapshot();
   });
 

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -14,6 +14,19 @@ import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaButtonLink } from '../MaLink/MaLink.tsx';
 import { ModalAndButton } from '../Modal/Modal.tsx';
 
+function createHeading(afspraak: AfspraakFrontend): string {
+  if (afspraak.products.length > 1) {
+    const productNames = afspraak.products.map((product) => product.name);
+
+    return new Intl.ListFormat('nl', {
+      style: 'long',
+      type: 'conjunction',
+    }).format(productNames);
+  }
+
+  return afspraak.subject;
+}
+
 type AfspraakCardProps = {
   afspraak: AfspraakFrontend;
   className?: string;
@@ -31,7 +44,7 @@ export function AfspraakCard({
         {!compact && <Icon svg={PersonAtDeskIcon} hidden size="heading-2" />}
         <div className="ams-prose">
           <Heading level={3} size="level-3">
-            {afspraak.subject}
+            {createHeading(afspraak)}
           </Heading>
           <Paragraph>
             Datum:{' '}

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -89,16 +89,9 @@ function FullContent({
       <DescriptionList className={isPhoneScreen ? 'ams-mb-xl' : 'ams-mb-m'}>
         <DescriptionList.Term>Datum</DescriptionList.Term>
         <DescriptionList.Description>
-          <MaLink
-            href={afspraak.icsLink.to}
-            rel="noopener noreferrer"
-            type="text/calendar"
-            download={afspraak.icsLink.download}
-          >
-            <time dateTime={afspraak.dateStart}>
-              {capitalizeFirstLetter(afspraak.displayDateTime)}
-            </time>
-          </MaLink>
+          <time dateTime={afspraak.dateStart}>
+            {capitalizeFirstLetter(afspraak.displayDateTime)}
+          </time>
         </DescriptionList.Description>
         <DescriptionList.Term>Locatie</DescriptionList.Term>
         <DescriptionList.Description>

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -102,14 +102,18 @@ function FullContent({
         </DescriptionList.Description>
         <DescriptionList.Term>Locatie</DescriptionList.Term>
         <DescriptionList.Description>
-          <LocationModal
-            modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
-            address={afspraak.location.street}
-            buttonLabel={`Stadsloket ${afspraak.location.name}${
-              afspraak.location.street ? `, ${afspraak.location.street}` : ''
-            }`}
-            buttonVariant="ma-link-like"
-          />
+          {afspraak.location.street ? (
+            <LocationModal
+              modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
+              address={afspraak.location.street}
+              buttonLabel={`Stadsloket ${afspraak.location.name}${
+                afspraak.location.street ? `, ${afspraak.location.street}` : ''
+              }`}
+              buttonVariant="ma-link-like"
+            />
+          ) : (
+            <>Stadsloket {afspraak.location.name}</>
+          )}
         </DescriptionList.Description>
       </DescriptionList>
 

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -1,6 +1,6 @@
 import {
-  ActionGroup,
   Column,
+  DescriptionList,
   Heading,
   Icon,
   Paragraph,
@@ -10,12 +10,7 @@ import { PersonAtDeskIcon } from '@amsterdam/design-system-react-icons';
 import QRCode from 'react-qr-code';
 
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
-import { Breakpoints } from '../../config/app.ts';
-import {
-  useMediaLayout,
-  useMediumScreen,
-  useSmallScreen,
-} from '../../hooks/media.hook.ts';
+import { useSmallScreen } from '../../hooks/media.hook.ts';
 import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaLink } from '../MaLink/MaLink.tsx';
 import { ModalAndButton } from '../Modal/Modal.tsx';
@@ -44,10 +39,6 @@ export function AfspraakCard({
   className,
   compact,
 }: AfspraakCardProps) {
-  const isMedium = useMediaLayout({
-    minWidth: Breakpoints.medium,
-  });
-
   const isPhoneScreen = useSmallScreen();
 
   return (
@@ -56,69 +47,16 @@ export function AfspraakCard({
         <Row>
           {!compact && <Icon svg={PersonAtDeskIcon} hidden size="heading-2" />}
           <div className="ams-prose">
-            <Heading level={3} size="level-3">
+            <Heading
+              level={3}
+              size="level-3"
+              className={!compact ? 'ams-mb-l' : ''}
+            >
               {createHeading(afspraak)}
             </Heading>
-            <Paragraph>
-              Datum:{' '}
-              <time dateTime={afspraak.dateStart}>
-                {afspraak.displayDateTime}
-              </time>
-            </Paragraph>
-            <Paragraph className="ams-mb-s">
-              Locatie: Stadsloket {afspraak.location.name}
-              {afspraak.location.street && `, ${afspraak.location.street}`}
-            </Paragraph>
+            {compact && <CompactContent afspraak={afspraak} />}
             {!compact && (
-              <>
-                <ResponsiveActionGroup>
-                  {isPhoneScreen && (
-                    <ModalAndButton
-                      modal={{
-                        title: `QR code - Stadsloket ${afspraak.location.name}`,
-                      }}
-                      buttonVariant="secondary"
-                      buttonLabel="Toon QR code"
-                    >
-                      <>
-                        <QRCode
-                          size={256}
-                          value={afspraak.qrCode}
-                          className="ams-mb-s"
-                        />
-                        <Paragraph className="ams-mb-l">
-                          Scan deze QR code op het stadsloket zodat de
-                          medewerker weet dat u op het stadsloket aanwezig bent.
-                        </Paragraph>
-                      </>
-                    </ModalAndButton>
-                  )}
-                  {afspraak.location.street && (
-                    <LocationModal
-                      modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
-                      address={afspraak.location.street}
-                      buttonLabel="Toon op kaart"
-                    />
-                  )}
-                  <MaLink
-                    href={afspraak.icsLink.to}
-                    rel="noopener noreferrer"
-                    type="text/calendar"
-                    maVariant="noDefaultUnderline"
-                  >
-                    Voeg toe aan uw agenda
-                  </MaLink>
-                  {isPhoneScreen && (
-                    <MaLink
-                      rel="noopener noreferrer"
-                      href={afspraak.cancellationLink}
-                      maVariant="noDefaultUnderline"
-                    >
-                      Annuleren
-                    </MaLink>
-                  )}
-                </ResponsiveActionGroup>
-              </>
+              <FullContent afspraak={afspraak} isPhoneScreen={isPhoneScreen} />
             )}
           </div>
         </Row>
@@ -136,26 +74,82 @@ export function AfspraakCard({
   );
 }
 
-export function ResponsiveActionGroup({
-  children,
+function FullContent({
+  afspraak,
+  isPhoneScreen,
 }: {
-  children: React.ReactNode;
+  afspraak: AfspraakFrontend;
+  isPhoneScreen: boolean;
 }) {
-  const isMedium = useMediaLayout({
-    minWidth: Breakpoints.medium,
-  });
+  return (
+    <>
+      <DescriptionList className={isPhoneScreen ? 'ams-mb-xl' : 'ams-mb-m'}>
+        <DescriptionList.Term>Datum</DescriptionList.Term>
+        <DescriptionList.Description>
+          <MaLink
+            href={afspraak.icsLink.to}
+            rel="noopener noreferrer"
+            type="text/calendar"
+          >
+            <time dateTime={afspraak.dateStart}>
+              {afspraak.displayDateTime}
+            </time>
+          </MaLink>
+        </DescriptionList.Description>
+        <DescriptionList.Term>Locatie</DescriptionList.Term>
+        <DescriptionList.Description>
+          <LocationModal
+            modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
+            address={afspraak.location.street}
+            buttonLabel={`Stadsloket ${afspraak.location.name}${
+              afspraak.location.street ? `, ${afspraak.location.street}` : ''
+            }`}
+            buttonVariant="ma-link-like"
+          />
+        </DescriptionList.Description>
+      </DescriptionList>
 
-  const isSmallScreen = useSmallScreen();
-  const isMediumScreen = useMediumScreen();
+      <Column alignHorizontal="start" className="ams-mb-xl">
+        <ModalAndButton
+          modal={{
+            title: `QR code - Stadsloket ${afspraak.location.name}`,
+          }}
+          buttonVariant="secondary"
+          buttonLabel="Toon QR code"
+        >
+          <>
+            <QRCode size={256} value={afspraak.qrCode} className="ams-mb-s" />
+            <Paragraph className="ams-mb-l">
+              Scan deze QR code op het stadsloket zodat de medewerker weet dat u
+              op het stadsloket aanwezig bent.
+            </Paragraph>
+          </>
+        </ModalAndButton>
+        {isPhoneScreen && (
+          <MaLink
+            rel="noopener noreferrer"
+            href={afspraak.cancellationLink}
+            maVariant="noDefaultUnderline"
+          >
+            Afspraak annuleren
+          </MaLink>
+        )}
+      </Column>
+    </>
+  );
+}
 
-  // return <ActionGroup>{children}</ActionGroup>;
-
-  // if (isMedium) {
-  //   return <Row alignVertical="baseline">{children}</Row>;
-  // }
-  if (isMedium) {
-    return <ActionGroup>{children}</ActionGroup>;
-  }
-
-  return <Column>{children}</Column>;
+function CompactContent({ afspraak }: { afspraak: AfspraakFrontend }) {
+  return (
+    <>
+      <Paragraph>
+        Datum:{' '}
+        <time dateTime={afspraak.dateStart}>{afspraak.displayDateTime}</time>
+      </Paragraph>
+      <Paragraph className="ams-mb-s">
+        Locatie: Stadsloket {afspraak.location.name}
+        {afspraak.location.street && `, ${afspraak.location.street}`}
+      </Paragraph>
+    </>
+  );
 }

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -29,26 +29,74 @@ export function AfspraakCard({
 }: AfspraakCardProps) {
   const isPhoneScreen = useSmallScreen();
 
+  if (compact)
+    return <AfspraakCardDashboard afspraak={afspraak} className={className} />;
+
   return (
     <article className={className}>
       <Row align="between">
         <Row>
-          {!compact && <Icon svg={<IconAfspraak />} hidden size="heading-2" />}
-          <div className="ams-prose">
-            <Heading
-              level={3}
-              size="level-3"
-              className={!compact ? 'ams-mb-l' : ''}
+          <Icon svg={<IconAfspraak />} hidden size="heading-3" />
+          <Column alignHorizontal="start">
+            <AfspraakHeading>{afspraak.heading}</AfspraakHeading>
+            <DescriptionList className={isPhoneScreen ? 'ams-mb-m' : ''}>
+              <DescriptionList.Term>Datum</DescriptionList.Term>
+              <DescriptionList.Description>
+                <time dateTime={afspraak.dateStart}>
+                  {capitalizeFirstLetter(afspraak.displayDateTime)}
+                </time>
+              </DescriptionList.Description>
+              <DescriptionList.Term>Locatie</DescriptionList.Term>
+              <DescriptionList.Description>
+                {afspraak.location.street ? (
+                  <LocationModal
+                    modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
+                    address={afspraak.location.street}
+                    buttonLabel={`Stadsloket ${afspraak.location.name}${
+                      afspraak.location.street
+                        ? `, ${afspraak.location.street}`
+                        : ''
+                    }`}
+                    buttonVariant="ma-link-like"
+                  />
+                ) : (
+                  <>Stadsloket {afspraak.location.name}</>
+                )}
+              </DescriptionList.Description>
+            </DescriptionList>
+
+            <ModalAndButton
+              modal={{
+                title: `QR code - Stadsloket ${afspraak.location.name}`,
+              }}
+              buttonVariant="secondary"
+              buttonLabel="Toon QR code"
             >
-              {afspraak.heading}
-            </Heading>
-            {compact && <CompactContent afspraak={afspraak} />}
-            {!compact && (
-              <FullContent afspraak={afspraak} isPhoneScreen={isPhoneScreen} />
+              <>
+                <QRCode
+                  size={256}
+                  value={afspraak.qrCode}
+                  className="ams-mb-s"
+                />
+                <Paragraph className="ams-mb-l">
+                  Scan deze QR code op het stadsloket zodat de medewerker weet
+                  dat u op het stadsloket aanwezig bent.
+                </Paragraph>
+              </>
+            </ModalAndButton>
+            {isPhoneScreen && (
+              <MaLink
+                rel="noopener noreferrer"
+                href={afspraak.cancellationLink}
+                maVariant="noDefaultUnderline"
+                className="ams-mb-m"
+              >
+                Afspraak annuleren
+              </MaLink>
             )}
-          </div>
+          </Column>
         </Row>
-        {!compact && !isPhoneScreen && (
+        {!isPhoneScreen && (
           <Column>
             <MaLink
               rel="noopener noreferrer"
@@ -64,75 +112,13 @@ export function AfspraakCard({
   );
 }
 
-function FullContent({
+function AfspraakCardDashboard({
   afspraak,
-  isPhoneScreen,
-}: {
-  afspraak: AfspraakFrontend;
-  isPhoneScreen: boolean;
-}) {
+  className,
+}: Omit<AfspraakCardProps, 'compact'>) {
   return (
-    <>
-      <DescriptionList className={isPhoneScreen ? 'ams-mb-xl' : 'ams-mb-m'}>
-        <DescriptionList.Term>Datum</DescriptionList.Term>
-        <DescriptionList.Description>
-          <time dateTime={afspraak.dateStart}>
-            {capitalizeFirstLetter(afspraak.displayDateTime)}
-          </time>
-        </DescriptionList.Description>
-        <DescriptionList.Term>Locatie</DescriptionList.Term>
-        <DescriptionList.Description>
-          {afspraak.location.street ? (
-            <LocationModal
-              modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
-              address={afspraak.location.street}
-              buttonLabel={`Stadsloket ${afspraak.location.name}${
-                afspraak.location.street ? `, ${afspraak.location.street}` : ''
-              }`}
-              buttonVariant="ma-link-like"
-            />
-          ) : (
-            <>Stadsloket {afspraak.location.name}</>
-          )}
-        </DescriptionList.Description>
-      </DescriptionList>
-
-      <Column
-        alignHorizontal="start"
-        className={isPhoneScreen ? 'ams-mb-xl' : 'ams-mb-l'}
-      >
-        <ModalAndButton
-          modal={{
-            title: `QR code - Stadsloket ${afspraak.location.name}`,
-          }}
-          buttonVariant="secondary"
-          buttonLabel="Toon QR code"
-        >
-          <>
-            <QRCode size={256} value={afspraak.qrCode} className="ams-mb-s" />
-            <Paragraph className="ams-mb-l">
-              Scan deze QR code op het stadsloket zodat de medewerker weet dat u
-              op het stadsloket aanwezig bent.
-            </Paragraph>
-          </>
-        </ModalAndButton>
-        {isPhoneScreen && (
-          <MaLink
-            rel="noopener noreferrer"
-            href={afspraak.cancellationLink}
-            maVariant="noDefaultUnderline"
-          >
-            Afspraak annuleren
-          </MaLink>
-        )}
-      </Column>
-    </>
-  );
-}
-
-function CompactContent({ afspraak }: { afspraak: AfspraakFrontend }) {
-  return (
-    <>
+    <article className={className}>
+      <AfspraakHeading>{afspraak.heading}</AfspraakHeading>
       <Paragraph>
         Datum:{' '}
         <time dateTime={afspraak.dateStart}>{afspraak.displayDateTime}</time>
@@ -141,6 +127,14 @@ function CompactContent({ afspraak }: { afspraak: AfspraakFrontend }) {
         Locatie: Stadsloket {afspraak.location.name}
         {afspraak.location.street && `, ${afspraak.location.street}`}
       </Paragraph>
-    </>
+    </article>
+  );
+}
+
+function AfspraakHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <Heading level={3} size="level-3">
+      {children}
+    </Heading>
   );
 }

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -10,6 +10,7 @@ import { PersonAtDeskIcon } from '@amsterdam/design-system-react-icons';
 import QRCode from 'react-qr-code';
 
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
+import { capitalizeFirstLetter } from '../../../universal/helpers/text.ts';
 import { useSmallScreen } from '../../hooks/media.hook.ts';
 import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaLink } from '../MaLink/MaLink.tsx';
@@ -61,13 +62,15 @@ export function AfspraakCard({
           </div>
         </Row>
         {!compact && !isPhoneScreen && (
-          <MaLink
-            rel="noopener noreferrer"
-            maVariant="noDefaultUnderline"
-            href={afspraak.cancellationLink}
-          >
-            Annuleren
-          </MaLink>
+          <Column>
+            <MaLink
+              rel="noopener noreferrer"
+              maVariant="noDefaultUnderline"
+              href={afspraak.cancellationLink}
+            >
+              Annuleren
+            </MaLink>
+          </Column>
         )}
       </Row>
     </article>
@@ -92,7 +95,7 @@ function FullContent({
             type="text/calendar"
           >
             <time dateTime={afspraak.dateStart}>
-              {afspraak.displayDateTime}
+              {capitalizeFirstLetter(afspraak.displayDateTime)}
             </time>
           </MaLink>
         </DescriptionList.Description>
@@ -109,7 +112,10 @@ function FullContent({
         </DescriptionList.Description>
       </DescriptionList>
 
-      <Column alignHorizontal="start" className="ams-mb-xl">
+      <Column
+        alignHorizontal="start"
+        className={isPhoneScreen ? 'ams-mb-xl' : 'ams-mb-m'}
+      >
         <ModalAndButton
           modal={{
             title: `QR code - Stadsloket ${afspraak.location.name}`,

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -114,7 +114,7 @@ function FullContent({
 
       <Column
         alignHorizontal="start"
-        className={isPhoneScreen ? 'ams-mb-xl' : 'ams-mb-m'}
+        className={isPhoneScreen ? 'ams-mb-xl' : 'ams-mb-l'}
       >
         <ModalAndButton
           modal={{

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -19,18 +19,10 @@ import { ModalAndButton } from '../Modal/Modal.tsx';
 type AfspraakCardProps = {
   afspraak: AfspraakFrontend;
   className?: string;
-  dashboard?: boolean;
 };
 
-export function AfspraakCard({
-  afspraak,
-  className,
-  dashboard = false,
-}: AfspraakCardProps) {
+export function AfspraakCard({ afspraak, className }: AfspraakCardProps) {
   const isPhoneScreen = useSmallScreen();
-
-  if (dashboard)
-    return <AfspraakCardDashboard afspraak={afspraak} className={className} />;
 
   return (
     <article className={className}>
@@ -112,7 +104,7 @@ export function AfspraakCard({
   );
 }
 
-function AfspraakCardDashboard({
+export function AfspraakCardDashboard({
   afspraak,
   className,
 }: Omit<AfspraakCardProps, 'compact'>) {
@@ -123,7 +115,7 @@ function AfspraakCardDashboard({
         Datum:{' '}
         <time dateTime={afspraak.dateStart}>{afspraak.displayDateTime}</time>
       </Paragraph>
-      <Paragraph className="ams-mb-s">
+      <Paragraph>
         Locatie: Stadsloket {afspraak.location.name}
         {afspraak.location.street && `, ${afspraak.location.street}`}
       </Paragraph>

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -11,7 +11,7 @@ import QRCode from 'react-qr-code';
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
 import { useSmallScreen } from '../../hooks/media.hook.ts';
 import { LocationModal } from '../LocationModal/LocationModal.tsx';
-import { MaButtonLink } from '../MaLink/MaLink.tsx';
+import { MaLink } from '../MaLink/MaLink.tsx';
 import { ModalAndButton } from '../Modal/Modal.tsx';
 
 function createHeading(afspraak: AfspraakFrontend): string {
@@ -40,70 +40,67 @@ export function AfspraakCard({
 }: AfspraakCardProps) {
   return (
     <article className={className}>
-      <Row>
-        {!compact && <Icon svg={PersonAtDeskIcon} hidden size="heading-2" />}
-        <div className="ams-prose">
-          <Heading level={3} size="level-3">
-            {createHeading(afspraak)}
-          </Heading>
-          <Paragraph>
-            Datum:{' '}
-            <time dateTime={afspraak.dateStart}>
-              {afspraak.displayDateTime}
-            </time>
-          </Paragraph>
-          <Paragraph className="ams-mb-s">
-            Locatie: Stadsloket {afspraak.location.name}
-            {afspraak.location.street && `, ${afspraak.location.street}`}
-          </Paragraph>
-          {!compact && (
-            <>
-              <ResponsiveActionGroup>
-                <ModalAndButton
-                  modal={{
-                    title: `QR code - Stadsloket ${afspraak.location.name}`,
-                  }}
-                  buttonVariant="secondary"
-                  buttonLabel="Toon QR code"
-                >
-                  <>
-                    <QRCode
-                      size={256}
-                      value={afspraak.qrCode}
-                      className="ams-mb-s"
+      <Row align="between">
+        <Row>
+          {!compact && <Icon svg={PersonAtDeskIcon} hidden size="heading-2" />}
+          <div className="ams-prose">
+            <Heading level={3} size="level-3">
+              {createHeading(afspraak)}
+            </Heading>
+            <Paragraph>
+              Datum:{' '}
+              <time dateTime={afspraak.dateStart}>
+                {afspraak.displayDateTime}
+              </time>
+            </Paragraph>
+            <Paragraph className="ams-mb-s">
+              Locatie: Stadsloket {afspraak.location.name}
+              {afspraak.location.street && `, ${afspraak.location.street}`}
+            </Paragraph>
+            {!compact && (
+              <>
+                <ResponsiveActionGroup>
+                  <ModalAndButton
+                    modal={{
+                      title: `QR code - Stadsloket ${afspraak.location.name}`,
+                    }}
+                    buttonVariant="secondary"
+                    buttonLabel="Toon QR code"
+                  >
+                    <>
+                      <QRCode
+                        size={256}
+                        value={afspraak.qrCode}
+                        className="ams-mb-s"
+                      />
+                      <Paragraph className="ams-mb-l">
+                        Scan deze QR code op het stadsloket zodat de medewerker
+                        weet dat u op het stadsloket aanwezig bent.
+                      </Paragraph>
+                    </>
+                  </ModalAndButton>
+                  {afspraak.location.street && (
+                    <LocationModal
+                      modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
+                      address={afspraak.location.street}
+                      buttonLabel="Toon op kaart"
                     />
-                    <Paragraph className="ams-mb-l">
-                      Scan deze QR code op het stadsloket zodat de medewerker
-                      weet dat u op het stadsloket aanwezig bent.
-                    </Paragraph>
-                  </>
-                </ModalAndButton>
-                {afspraak.location.street && (
-                  <LocationModal
-                    modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
-                    address={afspraak.location.street}
-                    buttonLabel="Toon op kaart"
-                  />
-                )}
-                <MaButtonLink
-                  variant="tertiary"
-                  href={afspraak.icsLink.to}
-                  rel="noopener noreferrer"
-                  type="text/calendar"
-                >
-                  Voeg toe aan agenda
-                </MaButtonLink>
-                <MaButtonLink
-                  variant="tertiary"
-                  rel="noopener noreferrer"
-                  href={afspraak.cancellationLink}
-                >
-                  Afspraak annuleren
-                </MaButtonLink>
-              </ResponsiveActionGroup>
-            </>
-          )}
-        </div>
+                  )}
+                  <MaLink
+                    href={afspraak.icsLink.to}
+                    rel="noopener noreferrer"
+                    type="text/calendar"
+                  >
+                    Voeg toe aan uw agenda
+                  </MaLink>
+                </ResponsiveActionGroup>
+              </>
+            )}
+          </div>
+        </Row>
+        <MaLink rel="noopener noreferrer" href={afspraak.cancellationLink}>
+          Annuleren
+        </MaLink>
       </Row>
     </article>
   );

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -1,5 +1,5 @@
 import {
-  ActionGroup,
+  Column,
   Heading,
   Icon,
   Paragraph,
@@ -9,6 +9,7 @@ import { PersonAtDeskIcon } from '@amsterdam/design-system-react-icons';
 import QRCode from 'react-qr-code';
 
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
+import { useSmallScreen } from '../../hooks/media.hook.ts';
 import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaButtonLink } from '../MaLink/MaLink.tsx';
 import { ModalAndButton } from '../Modal/Modal.tsx';
@@ -44,7 +45,7 @@ export function AfspraakCard({
           </Paragraph>
           {!compact && (
             <>
-              <ActionGroup className="ams-mb-l">
+              <ResponsiveActionGroup>
                 <ModalAndButton
                   modal={{
                     title: `QR code - Stadsloket ${afspraak.location.name}`,
@@ -77,7 +78,7 @@ export function AfspraakCard({
                   rel="noopener noreferrer"
                   type="text/calendar"
                 >
-                  Voeg toe aan uw agenda
+                  Voeg toe aan agenda
                 </MaButtonLink>
                 <MaButtonLink
                   variant="tertiary"
@@ -86,11 +87,25 @@ export function AfspraakCard({
                 >
                   Afspraak annuleren
                 </MaButtonLink>
-              </ActionGroup>
+              </ResponsiveActionGroup>
             </>
           )}
         </div>
       </Row>
     </article>
   );
+}
+
+export function ResponsiveActionGroup({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const isSmallScreen = useSmallScreen();
+
+  if (isSmallScreen) {
+    return <Column>{children}</Column>;
+  }
+
+  return <Row>{children}</Row>;
 }

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -16,19 +16,6 @@ import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaLink } from '../MaLink/MaLink.tsx';
 import { ModalAndButton } from '../Modal/Modal.tsx';
 
-function createHeading(afspraak: AfspraakFrontend): string {
-  if (afspraak.products.length > 1) {
-    const productNames = afspraak.products.map((product) => product.name);
-
-    return new Intl.ListFormat('nl', {
-      style: 'long',
-      type: 'conjunction',
-    }).format(productNames);
-  }
-
-  return afspraak.subject;
-}
-
 type AfspraakCardProps = {
   afspraak: AfspraakFrontend;
   className?: string;
@@ -53,7 +40,7 @@ export function AfspraakCard({
               size="level-3"
               className={!compact ? 'ams-mb-l' : ''}
             >
-              {createHeading(afspraak)}
+              {afspraak.heading}
             </Heading>
             {compact && <CompactContent afspraak={afspraak} />}
             {!compact && (

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionGroup,
   Column,
   Heading,
   Icon,
@@ -9,7 +10,8 @@ import { PersonAtDeskIcon } from '@amsterdam/design-system-react-icons';
 import QRCode from 'react-qr-code';
 
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
-import { useSmallScreen } from '../../hooks/media.hook.ts';
+import { Breakpoints } from '../../config/app.ts';
+import { useMediaLayout } from '../../hooks/media.hook.ts';
 import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaLink } from '../MaLink/MaLink.tsx';
 import { ModalAndButton } from '../Modal/Modal.tsx';
@@ -98,9 +100,11 @@ export function AfspraakCard({
             )}
           </div>
         </Row>
-        <MaLink rel="noopener noreferrer" href={afspraak.cancellationLink}>
-          Annuleren
-        </MaLink>
+        {!compact && (
+          <MaLink rel="noopener noreferrer" href={afspraak.cancellationLink}>
+            Annuleren
+          </MaLink>
+        )}
       </Row>
     </article>
   );
@@ -111,11 +115,13 @@ export function ResponsiveActionGroup({
 }: {
   children: React.ReactNode;
 }) {
-  const isSmallScreen = useSmallScreen();
+  const isSmallOrMediumScreen = useMediaLayout({
+    minWidth: Breakpoints.medium,
+  });
 
-  if (isSmallScreen) {
-    return <Column>{children}</Column>;
+  if (isSmallOrMediumScreen) {
+    return <ActionGroup>{children}</ActionGroup>;
   }
 
-  return <Row>{children}</Row>;
+  return <Column alignHorizontal="start">{children}</Column>;
 }

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -2,15 +2,15 @@ import {
   Column,
   DescriptionList,
   Heading,
-  Icon,
   Paragraph,
   Row,
+  Icon,
 } from '@amsterdam/design-system-react';
-import { PersonAtDeskIcon } from '@amsterdam/design-system-react-icons';
 import QRCode from 'react-qr-code';
 
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
 import { capitalizeFirstLetter } from '../../../universal/helpers/text.ts';
+import { IconAfspraak } from '../../assets/icons/index.tsx';
 import { useSmallScreen } from '../../hooks/media.hook.ts';
 import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaLink } from '../MaLink/MaLink.tsx';
@@ -46,7 +46,7 @@ export function AfspraakCard({
     <article className={className}>
       <Row align="between">
         <Row>
-          {!compact && <Icon svg={PersonAtDeskIcon} hidden size="heading-2" />}
+          {!compact && <Icon svg={<IconAfspraak />} hidden size="heading-2" />}
           <div className="ams-prose">
             <Heading
               level={3}

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -11,7 +11,11 @@ import QRCode from 'react-qr-code';
 
 import type { AfspraakFrontend } from '../../../server/services/klantcontact/klantcontact.types.ts';
 import { Breakpoints } from '../../config/app.ts';
-import { useMediaLayout } from '../../hooks/media.hook.ts';
+import {
+  useMediaLayout,
+  useMediumScreen,
+  useSmallScreen,
+} from '../../hooks/media.hook.ts';
 import { LocationModal } from '../LocationModal/LocationModal.tsx';
 import { MaLink } from '../MaLink/MaLink.tsx';
 import { ModalAndButton } from '../Modal/Modal.tsx';
@@ -40,6 +44,12 @@ export function AfspraakCard({
   className,
   compact,
 }: AfspraakCardProps) {
+  const isMedium = useMediaLayout({
+    minWidth: Breakpoints.medium,
+  });
+
+  const isPhoneScreen = useSmallScreen();
+
   return (
     <article className={className}>
       <Row align="between">
@@ -62,25 +72,27 @@ export function AfspraakCard({
             {!compact && (
               <>
                 <ResponsiveActionGroup>
-                  <ModalAndButton
-                    modal={{
-                      title: `QR code - Stadsloket ${afspraak.location.name}`,
-                    }}
-                    buttonVariant="secondary"
-                    buttonLabel="Toon QR code"
-                  >
-                    <>
-                      <QRCode
-                        size={256}
-                        value={afspraak.qrCode}
-                        className="ams-mb-s"
-                      />
-                      <Paragraph className="ams-mb-l">
-                        Scan deze QR code op het stadsloket zodat de medewerker
-                        weet dat u op het stadsloket aanwezig bent.
-                      </Paragraph>
-                    </>
-                  </ModalAndButton>
+                  {isPhoneScreen && (
+                    <ModalAndButton
+                      modal={{
+                        title: `QR code - Stadsloket ${afspraak.location.name}`,
+                      }}
+                      buttonVariant="secondary"
+                      buttonLabel="Toon QR code"
+                    >
+                      <>
+                        <QRCode
+                          size={256}
+                          value={afspraak.qrCode}
+                          className="ams-mb-s"
+                        />
+                        <Paragraph className="ams-mb-l">
+                          Scan deze QR code op het stadsloket zodat de
+                          medewerker weet dat u op het stadsloket aanwezig bent.
+                        </Paragraph>
+                      </>
+                    </ModalAndButton>
+                  )}
                   {afspraak.location.street && (
                     <LocationModal
                       modalTitle={`Stadsloket ${afspraak.location.name} - ${afspraak.location.street}`}
@@ -92,16 +104,30 @@ export function AfspraakCard({
                     href={afspraak.icsLink.to}
                     rel="noopener noreferrer"
                     type="text/calendar"
+                    maVariant="noDefaultUnderline"
                   >
                     Voeg toe aan uw agenda
                   </MaLink>
+                  {isPhoneScreen && (
+                    <MaLink
+                      rel="noopener noreferrer"
+                      href={afspraak.cancellationLink}
+                      maVariant="noDefaultUnderline"
+                    >
+                      Annuleren
+                    </MaLink>
+                  )}
                 </ResponsiveActionGroup>
               </>
             )}
           </div>
         </Row>
-        {!compact && (
-          <MaLink rel="noopener noreferrer" href={afspraak.cancellationLink}>
+        {!compact && !isPhoneScreen && (
+          <MaLink
+            rel="noopener noreferrer"
+            maVariant="noDefaultUnderline"
+            href={afspraak.cancellationLink}
+          >
             Annuleren
           </MaLink>
         )}
@@ -115,13 +141,21 @@ export function ResponsiveActionGroup({
 }: {
   children: React.ReactNode;
 }) {
-  const isSmallOrMediumScreen = useMediaLayout({
+  const isMedium = useMediaLayout({
     minWidth: Breakpoints.medium,
   });
 
-  if (isSmallOrMediumScreen) {
+  const isSmallScreen = useSmallScreen();
+  const isMediumScreen = useMediumScreen();
+
+  // return <ActionGroup>{children}</ActionGroup>;
+
+  // if (isMedium) {
+  //   return <Row alignVertical="baseline">{children}</Row>;
+  // }
+  if (isMedium) {
     return <ActionGroup>{children}</ActionGroup>;
   }
 
-  return <Column alignHorizontal="start">{children}</Column>;
+  return <Column>{children}</Column>;
 }

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -93,6 +93,7 @@ function FullContent({
             href={afspraak.icsLink.to}
             rel="noopener noreferrer"
             type="text/calendar"
+            download={afspraak.icsLink.download}
           >
             <time dateTime={afspraak.dateStart}>
               {capitalizeFirstLetter(afspraak.displayDateTime)}

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -4,7 +4,6 @@ import {
   Icon,
   Paragraph,
   Row,
-  Column,
 } from '@amsterdam/design-system-react';
 import { PersonAtDeskIcon } from '@amsterdam/design-system-react-icons';
 import QRCode from 'react-qr-code';
@@ -29,7 +28,7 @@ export function AfspraakCard({
     <article className={className}>
       <Row>
         {!compact && <Icon svg={PersonAtDeskIcon} hidden size="heading-2" />}
-        <Column>
+        <div className="ams-prose">
           <Heading level={3} size="level-3">
             {afspraak.subject}
           </Heading>
@@ -90,7 +89,7 @@ export function AfspraakCard({
               </ActionGroup>
             </>
           )}
-        </Column>
+        </div>
       </Row>
     </article>
   );

--- a/src/client/components/AfspraakCard/AfspraakCard.tsx
+++ b/src/client/components/AfspraakCard/AfspraakCard.tsx
@@ -19,17 +19,17 @@ import { ModalAndButton } from '../Modal/Modal.tsx';
 type AfspraakCardProps = {
   afspraak: AfspraakFrontend;
   className?: string;
-  compact?: boolean;
+  dashboard?: boolean;
 };
 
 export function AfspraakCard({
   afspraak,
   className,
-  compact,
+  dashboard = false,
 }: AfspraakCardProps) {
   const isPhoneScreen = useSmallScreen();
 
-  if (compact)
+  if (dashboard)
     return <AfspraakCardDashboard afspraak={afspraak} className={className} />;
 
   return (

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
             </dd>
           </dl>
           <div
-            class="ams-column ams-column--align-horizontal-start ams-mb-m"
+            class="ams-column ams-column--align-horizontal-start ams-mb-l"
           >
             <button
               class="ams-button ams-button--secondary"

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Renders afspraak data > Compact variant 1`] = `
       class="ams-row"
     >
       <div
-        class="ams-column"
+        class="ams-prose"
       >
         <h3
           class="ams-heading ams-heading--3"
@@ -64,7 +64,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
         </svg>
       </span>
       <div
-        class="ams-column"
+        class="ams-prose"
       >
         <h3
           class="ams-heading ams-heading--3"
@@ -87,8 +87,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
           Locatie: Stadsloket Centrum, Amstel 1
         </p>
         <div
-          class="ams-action-group ams-mb-l"
-          role="group"
+          class="ams-row"
         >
           <button
             class="ams-button ams-button--secondary"
@@ -109,7 +108,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
             rel="noopener noreferrer"
             type="text/calendar"
           >
-            Voeg toe aan uw agenda
+            Voeg toe aan agenda
           </a>
           <a
             aria-disabled="false"

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -1,32 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Renders afspraak data > Compact variant 1`] = `
-<DocumentFragment>
-  <article>
-    <h3
-      class="ams-heading ams-heading--3"
-    >
-      Varen Afspraak
-    </h3>
-    <p
-      class="ams-paragraph"
-    >
-      Datum: 
-      <time
-        datetime="2020-01-17T17:50:00Z"
-      >
-        maandag 01 januari 2025 van 17:50 tot 18:20
-      </time>
-    </p>
-    <p
-      class="ams-paragraph ams-mb-s"
-    >
-      Locatie: Stadsloket Centrum, Amstel 1
-    </p>
-  </article>
-</DocumentFragment>
-`;
-
 exports[`Renders afspraak data > Dashboard variant 1`] = `
 <DocumentFragment>
   <article>
@@ -46,7 +19,7 @@ exports[`Renders afspraak data > Dashboard variant 1`] = `
       </time>
     </p>
     <p
-      class="ams-paragraph ams-mb-s"
+      class="ams-paragraph"
     >
       Locatie: Stadsloket Centrum, Amstel 1
     </p>

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -27,6 +27,33 @@ exports[`Renders afspraak data > Compact variant 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Renders afspraak data > Dashboard variant 1`] = `
+<DocumentFragment>
+  <article>
+    <h3
+      class="ams-heading ams-heading--3"
+    >
+      Varen Afspraak
+    </h3>
+    <p
+      class="ams-paragraph"
+    >
+      Datum: 
+      <time
+        datetime="2020-01-17T17:50:00Z"
+      >
+        maandag 01 januari 2025 van 17:50 tot 18:20
+      </time>
+    </p>
+    <p
+      class="ams-paragraph ams-mb-s"
+    >
+      Locatie: Stadsloket Centrum, Amstel 1
+    </p>
+  </article>
+</DocumentFragment>
+`;
+
 exports[`Renders afspraak data > Regular variant 1`] = `
 <DocumentFragment>
   <article>

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
             >
               <a
                 class="ams-link _MaLink_10c0a4"
+                download="afspraak-unique-123.ics"
                 href="data:text/calendar;base64,abc123"
                 rel="noopener noreferrer"
                 type="text/calendar"

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -3,38 +3,26 @@
 exports[`Renders afspraak data > Compact variant 1`] = `
 <DocumentFragment>
   <article>
-    <div
-      class="ams-row ams-row--align-between"
+    <h3
+      class="ams-heading ams-heading--3"
     >
-      <div
-        class="ams-row"
+      Varen Afspraak
+    </h3>
+    <p
+      class="ams-paragraph"
+    >
+      Datum: 
+      <time
+        datetime="2020-01-17T17:50:00Z"
       >
-        <div
-          class="ams-prose"
-        >
-          <h3
-            class="ams-heading ams-heading--3"
-          >
-            Varen Afspraak
-          </h3>
-          <p
-            class="ams-paragraph"
-          >
-            Datum: 
-            <time
-              datetime="2020-01-17T17:50:00Z"
-            >
-              maandag 01 januari 2025 van 17:50 tot 18:20
-            </time>
-          </p>
-          <p
-            class="ams-paragraph ams-mb-s"
-          >
-            Locatie: Stadsloket Centrum, Amstel 1
-          </p>
-        </div>
-      </div>
-    </div>
+        maandag 01 januari 2025 van 17:50 tot 18:20
+      </time>
+    </p>
+    <p
+      class="ams-paragraph ams-mb-s"
+    >
+      Locatie: Stadsloket Centrum, Amstel 1
+    </p>
   </article>
 </DocumentFragment>
 `;
@@ -49,7 +37,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
         class="ams-row"
       >
         <span
-          class="ams-icon ams-icon--heading-2"
+          class="ams-icon ams-icon--heading-3"
           hidden=""
         >
           <svg
@@ -73,15 +61,15 @@ exports[`Renders afspraak data > Regular variant 1`] = `
           </svg>
         </span>
         <div
-          class="ams-prose"
+          class="ams-column ams-column--align-horizontal-start"
         >
           <h3
-            class="ams-heading ams-heading--3 ams-mb-l"
+            class="ams-heading ams-heading--3"
           >
             Varen Afspraak
           </h3>
           <dl
-            class="ams-description-list ams-mb-m"
+            class="ams-description-list"
           >
             <dt
               class="ams-description-list__term"
@@ -113,16 +101,12 @@ exports[`Renders afspraak data > Regular variant 1`] = `
               </button>
             </dd>
           </dl>
-          <div
-            class="ams-column ams-column--align-horizontal-start ams-mb-l"
+          <button
+            class="ams-button ams-button--secondary"
+            type="button"
           >
-            <button
-              class="ams-button ams-button--secondary"
-              type="button"
-            >
-              Toon QR code
-            </button>
-          </div>
+            Toon QR code
+          </button>
         </div>
       </div>
       <div

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
                 <time
                   datetime="2020-01-17T17:50:00Z"
                 >
-                  maandag 01 januari 2025 van 17:50 tot 18:20
+                  Maandag 01 januari 2025 van 17:50 tot 18:20
                 </time>
               </a>
             </dd>
@@ -119,7 +119,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
             </dd>
           </dl>
           <div
-            class="ams-column ams-column--align-horizontal-start ams-mb-xl"
+            class="ams-column ams-column--align-horizontal-start ams-mb-m"
           >
             <button
               class="ams-button ams-button--secondary"
@@ -130,13 +130,17 @@ exports[`Renders afspraak data > Regular variant 1`] = `
           </div>
         </div>
       </div>
-      <a
-        class="ams-link _MaLink_10c0a4 _MaRouterLink__no-default-underline_10c0a4"
-        href="https://cancel.com"
-        rel="noopener noreferrer"
+      <div
+        class="ams-column"
       >
-        Annuleren
-      </a>
+        <a
+          class="ams-link _MaLink_10c0a4 _MaRouterLink__no-default-underline_10c0a4"
+          href="https://cancel.com"
+          rel="noopener noreferrer"
+        >
+          Annuleren
+        </a>
+      </div>
     </div>
   </article>
 </DocumentFragment>

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -4,31 +4,35 @@ exports[`Renders afspraak data > Compact variant 1`] = `
 <DocumentFragment>
   <article>
     <div
-      class="ams-row"
+      class="ams-row ams-row--align-between"
     >
       <div
-        class="ams-prose"
+        class="ams-row"
       >
-        <h3
-          class="ams-heading ams-heading--3"
+        <div
+          class="ams-prose"
         >
-          Varen
-        </h3>
-        <p
-          class="ams-paragraph"
-        >
-          Datum: 
-          <time
-            datetime="2020-01-17T17:50:00Z"
+          <h3
+            class="ams-heading ams-heading--3"
           >
-            maandag 01 januari 2025 van 17:50 tot 18:20
-          </time>
-        </p>
-        <p
-          class="ams-paragraph ams-mb-s"
-        >
-          Locatie: Stadsloket Centrum, Amstel 1
-        </p>
+            Varen
+          </h3>
+          <p
+            class="ams-paragraph"
+          >
+            Datum: 
+            <time
+              datetime="2020-01-17T17:50:00Z"
+            >
+              maandag 01 januari 2025 van 17:50 tot 18:20
+            </time>
+          </p>
+          <p
+            class="ams-paragraph ams-mb-s"
+          >
+            Locatie: Stadsloket Centrum, Amstel 1
+          </p>
+        </div>
       </div>
     </div>
   </article>
@@ -39,87 +43,100 @@ exports[`Renders afspraak data > Regular variant 1`] = `
 <DocumentFragment>
   <article>
     <div
-      class="ams-row"
+      class="ams-row ams-row--align-between"
     >
-      <span
-        class="ams-icon ams-icon--heading-2"
-        hidden=""
-      >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M23 13h-4v1h4v2h-1.5v4h-2v-4h-15v4h-2v-4H1v-2h1.72l.593-2.374a2 2 0 0 1 1.94-1.515h4.662a2 2 0 0 1 1.94 1.515L12.448 14H17v-1h-4V6h10zM4.782 14h5.605l-.472-1.889H5.254zM15 11h2v-1h2v1h2V8h-6z"
-            fill-rule="evenodd"
-          />
-          <path
-            clip-rule="evenodd"
-            d="M7.857 4.014a2.67 2.67 0 0 1 2.394 2.653l-.014.272a2.667 2.667 0 0 1-2.652 2.394l-.273-.014a2.67 2.67 0 0 1-2.38-2.38l-.014-.272A2.667 2.667 0 0 1 7.585 4zM7.585 6a.667.667 0 1 0 0 1.334.667.667 0 0 0 0-1.334"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </span>
       <div
-        class="ams-prose"
+        class="ams-row"
       >
-        <h3
-          class="ams-heading ams-heading--3"
+        <span
+          class="ams-icon ams-icon--heading-2"
+          hidden=""
         >
-          Varen
-        </h3>
-        <p
-          class="ams-paragraph"
-        >
-          Datum: 
-          <time
-            datetime="2020-01-17T17:50:00Z"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            maandag 01 januari 2025 van 17:50 tot 18:20
-          </time>
-        </p>
-        <p
-          class="ams-paragraph ams-mb-s"
-        >
-          Locatie: Stadsloket Centrum, Amstel 1
-        </p>
+            <path
+              clip-rule="evenodd"
+              d="M23 13h-4v1h4v2h-1.5v4h-2v-4h-15v4h-2v-4H1v-2h1.72l.593-2.374a2 2 0 0 1 1.94-1.515h4.662a2 2 0 0 1 1.94 1.515L12.448 14H17v-1h-4V6h10zM4.782 14h5.605l-.472-1.889H5.254zM15 11h2v-1h2v1h2V8h-6z"
+              fill-rule="evenodd"
+            />
+            <path
+              clip-rule="evenodd"
+              d="M7.857 4.014a2.67 2.67 0 0 1 2.394 2.653l-.014.272a2.667 2.667 0 0 1-2.652 2.394l-.273-.014a2.67 2.67 0 0 1-2.38-2.38l-.014-.272A2.667 2.667 0 0 1 7.585 4zM7.585 6a.667.667 0 1 0 0 1.334.667.667 0 0 0 0-1.334"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
         <div
-          class="ams-row"
+          class="ams-prose"
         >
-          <button
-            class="ams-button ams-button--secondary"
-            type="button"
+          <h3
+            class="ams-heading ams-heading--3 ams-mb-l"
           >
-            Toon QR code
-          </button>
-          <button
-            class="ams-button ams-button--secondary _LocationModalLink_fa327b"
-            type="button"
+            Varen
+          </h3>
+          <dl
+            class="ams-description-list ams-mb-m"
           >
-            Toon op kaart
-          </button>
-          <a
-            aria-disabled="false"
-            class="_MaButtonLink_10c0a4 ams-button ams-button--tertiary"
-            href="data:text/calendar;base64,abc123"
-            rel="noopener noreferrer"
-            type="text/calendar"
+            <dt
+              class="ams-description-list__term"
+            >
+              Datum
+            </dt>
+            <dd
+              class="ams-description-list__description"
+            >
+              <a
+                class="ams-link _MaLink_10c0a4"
+                href="data:text/calendar;base64,abc123"
+                rel="noopener noreferrer"
+                type="text/calendar"
+              >
+                <time
+                  datetime="2020-01-17T17:50:00Z"
+                >
+                  maandag 01 januari 2025 van 17:50 tot 18:20
+                </time>
+              </a>
+            </dd>
+            <dt
+              class="ams-description-list__term"
+            >
+              Locatie
+            </dt>
+            <dd
+              class="ams-description-list__description"
+            >
+              <button
+                class="ams-link _InlineButton_10c0a4 _LocationModalLink_fa327b"
+                type="button"
+              >
+                Stadsloket Centrum, Amstel 1
+              </button>
+            </dd>
+          </dl>
+          <div
+            class="ams-column ams-column--align-horizontal-start ams-mb-xl"
           >
-            Voeg toe aan agenda
-          </a>
-          <a
-            aria-disabled="false"
-            class="_MaButtonLink_10c0a4 ams-button ams-button--tertiary"
-            href="https://cancel.com"
-            rel="noopener noreferrer"
-          >
-            Afspraak annuleren
-          </a>
+            <button
+              class="ams-button ams-button--secondary"
+              type="button"
+            >
+              Toon QR code
+            </button>
+          </div>
         </div>
       </div>
+      <a
+        class="ams-link _MaLink_10c0a4 _MaRouterLink__no-default-underline_10c0a4"
+        href="https://cancel.com"
+        rel="noopener noreferrer"
+      >
+        Annuleren
+      </a>
     </div>
   </article>
 </DocumentFragment>

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -53,19 +53,21 @@ exports[`Renders afspraak data > Regular variant 1`] = `
           hidden=""
         >
           <svg
-            aria-hidden="true"
-            focusable="false"
-            viewBox="0 0 24 24"
+            fill="none"
+            height="28"
+            viewBox="0 0 28 28"
+            width="28"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              clip-rule="evenodd"
-              d="M23 13h-4v1h4v2h-1.5v4h-2v-4h-15v4h-2v-4H1v-2h1.72l.593-2.374a2 2 0 0 1 1.94-1.515h4.662a2 2 0 0 1 1.94 1.515L12.448 14H17v-1h-4V6h10zM4.782 14h5.605l-.472-1.889H5.254zM15 11h2v-1h2v1h2V8h-6z"
-              fill-rule="evenodd"
+              d="M14 5.98C15.6513 5.98 16.99 4.64133 16.99 2.99C16.99 1.33867 15.6513 0 14 0C12.3487 0 11.01 1.33867 11.01 2.99C11.01 4.64133 12.3487 5.98 14 5.98Z"
+            />
+            <path
+              d="M20 11.98V10.98C20 7.98 18.3 6.98 16 6.98H12C9.69 6.98 8 7.98 8 10.98V11.98H20Z"
             />
             <path
               clip-rule="evenodd"
-              d="M7.857 4.014a2.67 2.67 0 0 1 2.394 2.653l-.014.272a2.667 2.667 0 0 1-2.652 2.394l-.273-.014a2.67 2.67 0 0 1-2.38-2.38l-.014-.272A2.667 2.667 0 0 1 7.585 4zM7.585 6a.667.667 0 1 0 0 1.334.667.667 0 0 0 0-1.334"
+              d="M26 28H24V26H4V28H2V16H0V14H28V16H26V28ZM24 22V18H4V22H24Z"
               fill-rule="evenodd"
             />
           </svg>

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Renders afspraak data > Compact variant 1`] = `
           <h3
             class="ams-heading ams-heading--3"
           >
-            Varen
+            Varen Afspraak
           </h3>
           <p
             class="ams-paragraph"
@@ -78,7 +78,7 @@ exports[`Renders afspraak data > Regular variant 1`] = `
           <h3
             class="ams-heading ams-heading--3 ams-mb-l"
           >
-            Varen
+            Varen Afspraak
           </h3>
           <dl
             class="ams-description-list ams-mb-m"

--- a/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
+++ b/src/client/components/AfspraakCard/__snapshots__/AfspraakCard.test.tsx.snap
@@ -91,19 +91,11 @@ exports[`Renders afspraak data > Regular variant 1`] = `
             <dd
               class="ams-description-list__description"
             >
-              <a
-                class="ams-link _MaLink_10c0a4"
-                download="afspraak-unique-123.ics"
-                href="data:text/calendar;base64,abc123"
-                rel="noopener noreferrer"
-                type="text/calendar"
+              <time
+                datetime="2020-01-17T17:50:00Z"
               >
-                <time
-                  datetime="2020-01-17T17:50:00Z"
-                >
-                  Maandag 01 januari 2025 van 17:50 tot 18:20
-                </time>
-              </a>
+                Maandag 01 januari 2025 van 17:50 tot 18:20
+              </time>
             </dd>
             <dt
               class="ams-description-list__term"

--- a/src/client/components/LinkToListPage/LinkToListPage.tsx
+++ b/src/client/components/LinkToListPage/LinkToListPage.tsx
@@ -1,7 +1,7 @@
 import { generatePath } from 'react-router';
 
 import { MAX_TABLE_ROWS_ON_THEMA_PAGINA } from '../../config/app.ts';
-import { MaRouterLink } from '../MaLink/MaLink.tsx';
+import { MaRouterLink, type MaClassNameVariant } from '../MaLink/MaLink.tsx';
 
 interface LinkToListPageProps {
   count: number;
@@ -11,6 +11,7 @@ interface LinkToListPageProps {
   params?: Record<string, string>;
   threshold?: number;
   translateX?: string;
+  maVariant?: MaClassNameVariant;
 }
 
 export function LinkToListPage({
@@ -20,14 +21,11 @@ export function LinkToListPage({
   count,
   route,
   params,
+  maVariant = 'noDefaultUnderline',
 }: LinkToListPageProps) {
   const routeGenerated = generatePath(route, params);
   return count > threshold ? (
-    <MaRouterLink
-      title={linkTitle}
-      maVariant="noDefaultUnderline"
-      href={routeGenerated}
-    >
+    <MaRouterLink title={linkTitle} maVariant={maVariant} href={routeGenerated}>
       {label}
     </MaRouterLink>
   ) : null;

--- a/src/client/components/MaLink/MaLink.tsx
+++ b/src/client/components/MaLink/MaLink.tsx
@@ -12,11 +12,12 @@ import { useLocation, useNavigate } from 'react-router';
 import styles from './MaLink.module.scss';
 import { usePageTypeSettingValue } from '../../hooks/usePageTypeSetting.ts';
 
-type MaClassNameVariant =
+export type MaClassNameVariant =
   | 'fatNoUnderline'
   | 'noDefaultUnderline'
   | 'noUnderline'
-  | 'fatNoDefaultUnderline';
+  | 'fatNoDefaultUnderline'
+  | 'default';
 
 type MaLinkProps = LinkProps & {
   maVariant?: MaClassNameVariant;
@@ -27,6 +28,7 @@ const maClassName: Record<MaClassNameVariant, string> = {
   noDefaultUnderline: 'MaRouterLink__no-default-underline',
   fatNoDefaultUnderline: 'MaRouterLink__no-default-underline-fat',
   noUnderline: 'MaRouterLink__no-underline',
+  default: '',
 };
 
 export function MaLink({

--- a/src/client/pages/Dashboard/Dashboard.test.tsx
+++ b/src/client/pages/Dashboard/Dashboard.test.tsx
@@ -12,7 +12,6 @@ import type { AfspraakFrontend } from '../../../server/services/klantcontact/kla
 import { remoteApiHost } from '../../../testing/setup.ts';
 import { bffApi } from '../../../testing/utils.ts';
 import { toDateFormatted } from '../../../universal/helpers/date.ts';
-import { MAX_TABLE_ROWS_ON_THEMA_PAGINA } from '../../config/app.ts';
 
 const DATE_NOW = '2021-09-22T09:00:00';
 
@@ -131,8 +130,12 @@ describe('<Dashboard />', () => {
       const Component = createDashboardComponent(state);
       const screen = render(<Component />);
 
-      screen.getByRole('heading', { name: 'Afspraken bij een Stadsloket' });
-      screen.getByRole('heading', { name: 'Varen Afspraak' });
+      expect(
+        screen.getByRole('heading', { name: 'Afspraken bij een Stadsloket' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'Varen Afspraak' })
+      ).toBeInTheDocument();
     });
 
     it('Does not display Panel when there are no afspraken', () => {
@@ -148,18 +151,15 @@ describe('<Dashboard />', () => {
       const Component = createDashboardComponent(state);
       const screen = render(<Component />);
 
-      expect(screen.getByRole('heading', { name: 'Goedemorgen' }));
+      expect(
+        screen.getByRole('heading', { name: 'Goedemorgen' })
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole('heading', { name: 'Aankomende afspraken' })
       ).not.toBeInTheDocument();
     });
 
     it('Displays no afspraken component, if there are 0 afspraken', () => {
-      const afspraken = new Array(MAX_TABLE_ROWS_ON_THEMA_PAGINA)
-        .fill(afspraak)
-        // caseReference is used as key in react, so it must be unique from other items.
-        .map((a, i) => ({ ...a, caseReference: i }));
-
       const state = {
         KLANT_CONTACT: {
           status: 'OK',

--- a/src/client/pages/Dashboard/Dashboard.test.tsx
+++ b/src/client/pages/Dashboard/Dashboard.test.tsx
@@ -35,6 +35,11 @@ const afspraak: AfspraakFrontend = {
   qrCode: 'xxxxxxxxxxxxxxxxxxxx',
   status: 'New',
   subject: 'Varen Afspraak',
+  products: [
+    {
+      name: 'Varen Afspraak',
+    },
+  ],
   link: {
     to: '/afspraak/00157784',
     title: 'Bekijk afspraak',

--- a/src/client/pages/Dashboard/Dashboard.test.tsx
+++ b/src/client/pages/Dashboard/Dashboard.test.tsx
@@ -34,10 +34,11 @@ const afspraak: AfspraakFrontend = {
   },
   qrCode: 'xxxxxxxxxxxxxxxxxxxx',
   status: 'New',
-  subject: 'Varen Afspraak',
+  subject: 'Varen',
+  heading: 'Varen Afspraak',
   products: [
     {
-      name: 'Varen Afspraak',
+      name: 'Varen',
     },
   ],
   link: {

--- a/src/client/pages/Dashboard/Dashboard.test.tsx
+++ b/src/client/pages/Dashboard/Dashboard.test.tsx
@@ -34,13 +34,7 @@ const afspraak: AfspraakFrontend = {
   },
   qrCode: 'xxxxxxxxxxxxxxxxxxxx',
   status: 'New',
-  subject: 'Varen',
   heading: 'Varen Afspraak',
-  products: [
-    {
-      name: 'Varen',
-    },
-  ],
   link: {
     to: '/afspraak/00157784',
     title: 'Bekijk afspraak',

--- a/src/client/pages/Dashboard/Dashboard.tsx
+++ b/src/client/pages/Dashboard/Dashboard.tsx
@@ -75,7 +75,7 @@ export function Dashboard() {
             <Afspraken
               className="ams-mb-l"
               afspraken={afspraken}
-              compact={true}
+              dashboard={true}
               maxItems={1}
             />
           )}

--- a/src/client/pages/Dashboard/Dashboard.tsx
+++ b/src/client/pages/Dashboard/Dashboard.tsx
@@ -21,7 +21,7 @@ import { useHTMLDocumentTitle } from '../../hooks/useHTMLDocumentTitle.ts';
 import { useAppStateNotifications } from '../../hooks/useNotifications.ts';
 import { useActiveThemaMenuItems } from '../../hooks/useThemaMenuItems.ts';
 import { myNotificationsMenuItem } from '../MyNotifications/MyNotifications-routes.ts';
-import { Afspraken } from '../Thema/KlantContact/Afspraken/Afspraken.tsx';
+import { AfsprakenDashboard } from '../Thema/KlantContact/Afspraken/Afspraken.tsx';
 import { useKlantcontactData } from '../Thema/KlantContact/useKlantcontactData.hook.tsx';
 
 const MAX_NOTIFICATIONS_VISIBLE = 6;
@@ -72,12 +72,7 @@ export function Dashboard() {
         >
           {isKlantcontactLoading && <LoadingContent className="ams-mb-l" />}
           {!isKlantcontactLoading && hasAfspraken && (
-            <Afspraken
-              className="ams-mb-l"
-              afspraken={afspraken}
-              dashboard={true}
-              maxItems={1}
-            />
+            <AfsprakenDashboard afspraken={afspraken} className="ams-mb-l" />
           )}
 
           <Heading level={2} className="ams-mb-m">

--- a/src/client/pages/Dashboard/Dashboard.tsx
+++ b/src/client/pages/Dashboard/Dashboard.tsx
@@ -20,9 +20,9 @@ import { useAppStateGetter } from '../../hooks/useAppStateStore.ts';
 import { useHTMLDocumentTitle } from '../../hooks/useHTMLDocumentTitle.ts';
 import { useAppStateNotifications } from '../../hooks/useNotifications.ts';
 import { useActiveThemaMenuItems } from '../../hooks/useThemaMenuItems.ts';
-import { useKlantcontactData } from '../Thema/KlantContact/useKlantcontactData.hook.tsx';
 import { myNotificationsMenuItem } from '../MyNotifications/MyNotifications-routes.ts';
 import { Afspraken } from '../Thema/KlantContact/Afspraken/Afspraken.tsx';
+import { useKlantcontactData } from '../Thema/KlantContact/useKlantcontactData.hook.tsx';
 
 const MAX_NOTIFICATIONS_VISIBLE = 6;
 
@@ -70,7 +70,7 @@ export function Dashboard() {
           spanWide={7}
           className={getRedactedClass(null, 'full')}
         >
-          {isKlantcontactLoading && <LoadingContent />}
+          {isKlantcontactLoading && <LoadingContent className="ams-mb-l" />}
           {!isKlantcontactLoading && hasAfspraken && (
             <Afspraken
               className="ams-mb-l"

--- a/src/client/pages/Thema/KlantContact/Afspraken/AfspraakListPage.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/AfspraakListPage.tsx
@@ -1,4 +1,4 @@
-import { Paragraph } from '@amsterdam/design-system-react';
+import { Column, Paragraph } from '@amsterdam/design-system-react';
 
 import { AfspraakCard } from '../../../../components/AfspraakCard/AfspraakCard.tsx';
 import { PageV2, PageContentCell } from '../../../../components/Page/Page.tsx';
@@ -16,13 +16,11 @@ export function AfspraakListPage() {
           afspraken waarbij we uw persoonsgegevens nodig hebben om uw vraag te
           beantwoorden.
         </Paragraph>
-        {afspraken.map((afspraak) => (
-          <AfspraakCard
-            key={afspraak.caseReference}
-            afspraak={afspraak}
-            className="ams-mb-l"
-          />
-        ))}
+        <Column gap="large">
+          {afspraken.map((afspraak) => (
+            <AfspraakCard key={afspraak.caseReference} afspraak={afspraak} />
+          ))}
+        </Column>
       </PageContentCell>
     </PageV2>
   );

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
@@ -122,24 +122,4 @@ describe('Afspraken', () => {
       })
     ).not.toBeInTheDocument();
   });
-
-  test('does show link to list page when count is not above threshold, but dashboardMode is true', () => {
-    const afspraken = [createAfspraak(1)];
-    const screen = render(
-      <Afspraken
-        afspraken={afspraken}
-        maxItems={1}
-        isLoading={false}
-        dashboard={true}
-      />,
-      {
-        wrapper: BrowserRouter,
-      }
-    );
-
-    const listLink = screen.getByRole('link', {
-      name: 'Bekijk uw 1 afspraak',
-    });
-    expect(listLink).toHaveAttribute('href', '/mijn-contact/afspraken');
-  });
 });

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
@@ -63,25 +63,6 @@ describe('Afspraken', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders only maxAmountAfspraakDisplayed afspraken and shows link to list page', () => {
-    const afspraken = [createAfspraak(1), createAfspraak(2), createAfspraak(3)];
-    const screen = render(
-      <Afspraken afspraken={afspraken} maxItems={2} isLoading={false} />,
-      {
-        wrapper: BrowserRouter,
-      }
-    );
-
-    expect(screen.getByText('Afspraak 1')).toBeInTheDocument();
-    expect(screen.getByText('Afspraak 2')).toBeInTheDocument();
-    expect(screen.queryByText('Afspraak 3')).not.toBeInTheDocument();
-
-    const listLink = screen.getByRole('link', {
-      name: 'Bekijk uw 3 afspraken',
-    });
-    expect(listLink).toHaveAttribute('href', '/mijn-contact/afspraken');
-  });
-
   test('renders amount of afspraken based on thema config', () => {
     const afspraken = [
       createAfspraak(1),
@@ -110,7 +91,7 @@ describe('Afspraken', () => {
   test('does not show link to list page when count is not above threshold', () => {
     const afspraken = [createAfspraak(1), createAfspraak(2)];
     const screen = render(
-      <Afspraken afspraken={afspraken} maxItems={2} isLoading={false} />,
+      <Afspraken afspraken={afspraken} isLoading={false} />,
       {
         wrapper: BrowserRouter,
       }

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
@@ -130,7 +130,7 @@ describe('Afspraken', () => {
         afspraken={afspraken}
         maxItems={1}
         isLoading={false}
-        compact={true}
+        dashboard={true}
       />,
       {
         wrapper: BrowserRouter,

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
@@ -8,6 +8,11 @@ function createAfspraak(index: number): AfspraakFrontend {
   return {
     cancellationLink: `https://example.org/cancel/${index}`,
     caseReference: `ref-${index}`,
+    products: [
+      {
+        name: `Product ${index}`,
+      },
+    ],
     dateStartFormatted: '26 februari 2026',
     dateEndFormatted: '26 februari 2026',
     dateStart: `2026-02-26T0${index}:00:00Z`,

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
@@ -8,11 +8,6 @@ function createAfspraak(index: number): AfspraakFrontend {
   return {
     cancellationLink: `https://example.org/cancel/${index}`,
     caseReference: `ref-${index}`,
-    products: [
-      {
-        name: `Product ${index}`,
-      },
-    ],
     dateStartFormatted: '26 februari 2026',
     dateEndFormatted: '26 februari 2026',
     dateStart: `2026-02-26T0${index}:00:00Z`,
@@ -27,7 +22,6 @@ function createAfspraak(index: number): AfspraakFrontend {
     },
     qrCode: `qr-${index}`,
     status: 'New',
-    subject: `Afspraak ${index}`,
     heading: `Afspraak ${index}`,
     link: {
       to: `/afspraak/ref-${index}`,

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
@@ -28,6 +28,7 @@ function createAfspraak(index: number): AfspraakFrontend {
     qrCode: `qr-${index}`,
     status: 'New',
     subject: `Afspraak ${index}`,
+    heading: `Afspraak ${index}`,
     link: {
       to: `/afspraak/ref-${index}`,
       title: 'Bekijk afspraak',

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.test.tsx
@@ -123,7 +123,7 @@ describe('Afspraken', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('does show link to list page when count is not above threshold, but compactmodus is true', () => {
+  test('does show link to list page when count is not above threshold, but dashboardMode is true', () => {
     const afspraken = [createAfspraak(1)];
     const screen = render(
       <Afspraken

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { Heading, Paragraph } from '@amsterdam/design-system-react';
+import { Column } from '@amsterdam/design-system-react';
 
 import type { AfspraakFrontend } from '../../../../../server/services/klantcontact/klantcontact.types.ts';
 import { AfspraakCard } from '../../../../components/AfspraakCard/AfspraakCard.tsx';
@@ -42,13 +43,15 @@ export function Afspraken({
 
   return (
     <AfsprakenBase className={className} compact={compact}>
-      {afspraken.slice(0, maxItems).map((afspraak) => (
-        <AfspraakCard
-          compact={compact}
-          key={afspraak.caseReference}
-          afspraak={afspraak}
-        />
-      ))}
+      <Column gap="large" className={!compact ? 'ams-mb-l' : ''}>
+        {afspraken.slice(0, maxItems).map((afspraak) => (
+          <AfspraakCard
+            compact={compact}
+            key={afspraak.caseReference}
+            afspraak={afspraak}
+          />
+        ))}
+      </Column>
       <LinkToListPage
         count={afspraken.length}
         route={themaConfig.listPageAfspraken.route.path}

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
@@ -54,6 +54,7 @@ export function Afspraken({
         route={themaConfig.listPageAfspraken.route.path}
         threshold={compact ? 0 : maxItems}
         label={`Bekijk uw ${afspraken.length} ${afspraken.length === 1 ? 'afspraak' : 'afspraken'}`}
+        maVariant="default"
       />
     </AfsprakenBase>
   );

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
@@ -11,7 +11,7 @@ import { MAX_TABLE_ROWS_ON_THEMA_PAGINA } from '../../../../config/app.ts';
 import { themaConfig } from '../KlantContact-thema-config.ts';
 
 type AfsprakenProps = {
-  compact?: boolean;
+  dashboard?: boolean;
   afspraken: AfspraakFrontend[];
   className?: string;
   maxItems?: number;
@@ -19,7 +19,7 @@ type AfsprakenProps = {
 };
 
 export function Afspraken({
-  compact = false,
+  dashboard = false,
   afspraken = [],
   maxItems = MAX_TABLE_ROWS_ON_THEMA_PAGINA,
   className,
@@ -29,24 +29,24 @@ export function Afspraken({
 
   if (isLoading)
     return (
-      <AfsprakenBase className={className} compact={compact}>
+      <AfsprakenBase className={className} dashboard={dashboard}>
         <LoadingContent />
       </AfsprakenBase>
     );
 
   if (!hasAfspraken)
     return (
-      <AfsprakenBase className={className} compact={compact}>
+      <AfsprakenBase className={className} dashboard={dashboard}>
         <Paragraph>Er zijn geen afspraken bij het Stadsloket.</Paragraph>
       </AfsprakenBase>
     );
 
   return (
-    <AfsprakenBase className={className} compact={compact}>
-      <Column gap="large" className={!compact ? 'ams-mb-l' : ''}>
+    <AfsprakenBase className={className} dashboard={dashboard}>
+      <Column gap="large" className={!dashboard ? 'ams-mb-l' : ''}>
         {afspraken.slice(0, maxItems).map((afspraak) => (
           <AfspraakCard
-            compact={compact}
+            dashboard={dashboard}
             key={afspraak.caseReference}
             afspraak={afspraak}
           />
@@ -55,7 +55,7 @@ export function Afspraken({
       <LinkToListPage
         count={afspraken.length}
         route={themaConfig.listPageAfspraken.route.path}
-        threshold={compact ? 0 : maxItems}
+        threshold={dashboard ? 0 : maxItems}
         label={`Bekijk uw ${afspraken.length} ${afspraken.length === 1 ? 'afspraak' : 'afspraken'}`}
         maVariant="default"
       />
@@ -66,20 +66,20 @@ export function Afspraken({
 type AfsprakenBaseProps = {
   className?: string;
   children: ReactNode;
-  compact: boolean;
+  dashboard: boolean;
 };
 
 export function AfsprakenBase({
   className,
   children,
-  compact,
+  dashboard,
 }: AfsprakenBaseProps) {
   return (
     <div className={className}>
       <Heading level={2} className="ams-mb-m">
         Afspraken bij een Stadsloket
       </Heading>
-      {!compact && (
+      {!dashboard && (
         <Paragraph className="ams-mb-m">
           Hier ziet u niet al uw afspraken. In het overzicht ziet u alleen de
           afspraken waarbij we uw persoonsgegevens nodig hebben om uw vraag te

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
@@ -4,7 +4,10 @@ import { Heading, Paragraph } from '@amsterdam/design-system-react';
 import { Column } from '@amsterdam/design-system-react';
 
 import type { AfspraakFrontend } from '../../../../../server/services/klantcontact/klantcontact.types.ts';
-import { AfspraakCard } from '../../../../components/AfspraakCard/AfspraakCard.tsx';
+import {
+  AfspraakCard,
+  AfspraakCardDashboard,
+} from '../../../../components/AfspraakCard/AfspraakCard.tsx';
 import { LinkToListPage } from '../../../../components/LinkToListPage/LinkToListPage.tsx';
 import { LoadingContent } from '../../../../components/LoadingContent/LoadingContent.tsx';
 import { MAX_TABLE_ROWS_ON_THEMA_PAGINA } from '../../../../config/app.ts';
@@ -19,7 +22,6 @@ type AfsprakenProps = {
 };
 
 export function Afspraken({
-  dashboard = false,
   afspraken = [],
   maxItems = MAX_TABLE_ROWS_ON_THEMA_PAGINA,
   className,
@@ -29,33 +31,29 @@ export function Afspraken({
 
   if (isLoading)
     return (
-      <AfsprakenBase className={className} dashboard={dashboard}>
+      <AfsprakenBase className={className}>
         <LoadingContent />
       </AfsprakenBase>
     );
 
   if (!hasAfspraken)
     return (
-      <AfsprakenBase className={className} dashboard={dashboard}>
+      <AfsprakenBase className={className}>
         <Paragraph>Er zijn geen afspraken bij het Stadsloket.</Paragraph>
       </AfsprakenBase>
     );
 
   return (
-    <AfsprakenBase className={className} dashboard={dashboard}>
-      <Column gap="large" className={!dashboard ? 'ams-mb-l' : ''}>
+    <AfsprakenBase className={className}>
+      <Column gap="large" className="ams-mb-l">
         {afspraken.slice(0, maxItems).map((afspraak) => (
-          <AfspraakCard
-            dashboard={dashboard}
-            key={afspraak.caseReference}
-            afspraak={afspraak}
-          />
+          <AfspraakCard key={afspraak.caseReference} afspraak={afspraak} />
         ))}
       </Column>
       <LinkToListPage
         count={afspraken.length}
         route={themaConfig.listPageAfspraken.route.path}
-        threshold={dashboard ? 0 : maxItems}
+        threshold={maxItems}
         label={`Bekijk uw ${afspraken.length} ${afspraken.length === 1 ? 'afspraak' : 'afspraken'}`}
         maVariant="default"
       />
@@ -66,27 +64,42 @@ export function Afspraken({
 type AfsprakenBaseProps = {
   className?: string;
   children: ReactNode;
-  dashboard: boolean;
 };
 
-export function AfsprakenBase({
-  className,
-  children,
-  dashboard,
-}: AfsprakenBaseProps) {
+function AfsprakenBase({ className, children }: AfsprakenBaseProps) {
   return (
     <div className={className}>
-      <Heading level={2} className="ams-mb-m">
-        Afspraken bij een Stadsloket
-      </Heading>
-      {!dashboard && (
-        <Paragraph className="ams-mb-m">
-          Hier ziet u niet al uw afspraken. In het overzicht ziet u alleen de
-          afspraken waarbij we uw persoonsgegevens nodig hebben om uw vraag te
-          beantwoorden.
-        </Paragraph>
-      )}
+      <AfsprakenHeading />
+      <Paragraph className="ams-mb-m">
+        Hier ziet u niet al uw afspraken. In het overzicht ziet u alleen de
+        afspraken waarbij we uw persoonsgegevens nodig hebben om uw vraag te
+        beantwoorden.
+      </Paragraph>
       {children}
     </div>
+  );
+}
+
+export function AfsprakenDashboard({ afspraken, className }: AfsprakenProps) {
+  return (
+    <div className={className}>
+      <AfsprakenHeading />
+      <AfspraakCardDashboard afspraak={afspraken[0]} className="ams-mb-s" />
+      <LinkToListPage
+        count={1}
+        route={themaConfig.listPageAfspraken.route.path}
+        threshold={0}
+        label={`Bekijk uw ${afspraken.length} ${afspraken.length === 1 ? 'afspraak' : 'afspraken'}`}
+        maVariant="default"
+      />
+    </div>
+  );
+}
+
+export function AfsprakenHeading() {
+  return (
+    <Heading level={2} className="ams-mb-m">
+      Afspraken bij een Stadsloket
+    </Heading>
   );
 }

--- a/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
+++ b/src/client/pages/Thema/KlantContact/Afspraken/Afspraken.tsx
@@ -17,13 +17,11 @@ type AfsprakenProps = {
   dashboard?: boolean;
   afspraken: AfspraakFrontend[];
   className?: string;
-  maxItems?: number;
   isLoading?: boolean;
 };
 
 export function Afspraken({
   afspraken = [],
-  maxItems = MAX_TABLE_ROWS_ON_THEMA_PAGINA,
   className,
   isLoading = false,
 }: AfsprakenProps) {
@@ -46,14 +44,14 @@ export function Afspraken({
   return (
     <AfsprakenBase className={className}>
       <Column gap="large" className="ams-mb-l">
-        {afspraken.slice(0, maxItems).map((afspraak) => (
+        {afspraken.slice(0, MAX_TABLE_ROWS_ON_THEMA_PAGINA).map((afspraak) => (
           <AfspraakCard key={afspraak.caseReference} afspraak={afspraak} />
         ))}
       </Column>
       <LinkToListPage
         count={afspraken.length}
         route={themaConfig.listPageAfspraken.route.path}
-        threshold={maxItems}
+        threshold={MAX_TABLE_ROWS_ON_THEMA_PAGINA}
         label={`Bekijk uw ${afspraken.length} ${afspraken.length === 1 ? 'afspraak' : 'afspraken'}`}
         maVariant="default"
       />

--- a/src/client/pages/Thema/KlantContact/Contactmomenten/useTransformContactmomenten.tsx
+++ b/src/client/pages/Thema/KlantContact/Contactmomenten/useTransformContactmomenten.tsx
@@ -3,7 +3,6 @@ import {
   SpeechBalloonEllipsisIcon,
   MailIcon,
   PhoneIcon,
-  PersonAtDeskIcon,
 } from '@amsterdam/design-system-react-icons';
 
 import type {
@@ -26,6 +25,7 @@ import {
 import { themaConfig as themaZorg } from '../../Zorg/Zorg-thema-config.ts';
 import type { ContactmomentFrontendFinal } from '../KlantContact-thema-config.ts';
 import styles from './Contactmomenten.module.scss';
+import { IconAfspraak } from '../../../../assets/icons/index.tsx';
 
 // TODO: Use all the individual thema ID's imported from the Thema Config files.
 const SVWIv1ORv2 = featureToggleSvwi.svwiActive ? themaIdSvwi : themaInkomen.id;
@@ -77,7 +77,7 @@ function addIcon(type: Kanaal) {
     Telefoon: PhoneIcon,
     Chat: SpeechBalloonEllipsisIcon,
     Contactformulier: MailIcon,
-    Stadsloket: PersonAtDeskIcon,
+    Stadsloket: <IconAfspraak />,
   } as const;
   if (icons[type]) {
     return (

--- a/src/client/pages/Thema/KlantContact/KlantContact-render-config.tsx
+++ b/src/client/pages/Thema/KlantContact/KlantContact-render-config.tsx
@@ -1,11 +1,10 @@
-import { ConnectedCirclesIcon } from '@amsterdam/design-system-react-icons';
-
 import { AfspraakListPage } from './Afspraken/AfspraakListPage.tsx';
 import { ContactgegevenInstellen } from './Communicatievoorkeuren/ContactgegevenInstellen.tsx';
 import { ContactmomentenListPage } from './Contactmomenten/ContactmomentenListPage.tsx';
 import { themaConfig } from './KlantContact-thema-config.ts';
 import { KlantContactThema } from './KlantContactThema.tsx';
 import { isLoading } from '../../../../universal/helpers/api.ts';
+import { IconAfspraak } from '../../../assets/icons/index.tsx';
 import {
   type ThemaMenuItem,
   type ThemaRenderRouteConfig,
@@ -52,5 +51,5 @@ export const menuItem: ThemaMenuItem = {
         klantContactContent?.afspraken?.length)
     );
   },
-  IconSVG: ConnectedCirclesIcon,
+  IconSVG: IconAfspraak,
 };

--- a/src/client/pages/Thema/KlantContact/KlantContact-thema-config.ts
+++ b/src/client/pages/Thema/KlantContact/KlantContact-thema-config.ts
@@ -57,7 +57,7 @@ export const themaConfig = {
   },
   listPageAfspraken: {
     route: {
-      path: `/${BASE_PATH}/afspraken/:page?`,
+      path: `/${BASE_PATH}/afspraken?`,
       documentTitle: `Alle afspraken | ${THEMA_TITLE}`,
       trackingUrl: null,
     },

--- a/src/client/pages/Thema/KlantContact/KlantContact-thema-config.ts
+++ b/src/client/pages/Thema/KlantContact/KlantContact-thema-config.ts
@@ -57,7 +57,7 @@ export const themaConfig = {
   },
   listPageAfspraken: {
     route: {
-      path: `/${BASE_PATH}/afspraken?`,
+      path: `/${BASE_PATH}/afspraken`,
       documentTitle: `Alle afspraken | ${THEMA_TITLE}`,
       trackingUrl: null,
     },

--- a/src/client/pages/Thema/KlantContact/useContactmomentenListData.hook.tsx
+++ b/src/client/pages/Thema/KlantContact/useContactmomentenListData.hook.tsx
@@ -3,11 +3,11 @@ import {
   SpeechBalloonEllipsisIcon,
   MailIcon,
   PhoneIcon,
-  PersonAtDeskIcon,
 } from '@amsterdam/design-system-react-icons';
 
 import { useKlantcontactData } from './useKlantcontactData.hook.tsx';
 import type { Kanaal } from '../../../../server/services/klantcontact/klantcontact.types.ts';
+import { IconAfspraak } from '../../../assets/icons/index.tsx';
 import { MaRouterLink } from '../../../components/MaLink/MaLink.tsx';
 import type { ThemaMenuItemTransformed } from '../../../config/thema-types.ts';
 import { getRedactedClass } from '../../../helpers/cobrowse.ts';
@@ -74,7 +74,7 @@ function addIcon(type: Kanaal) {
     Telefoon: PhoneIcon,
     Chat: SpeechBalloonEllipsisIcon,
     Contactformulier: MailIcon,
-    Stadsloket: PersonAtDeskIcon,
+    Stadsloket: <IconAfspraak />,
   } as const;
   if (icons[type]) {
     return (

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -12,6 +12,7 @@
 @import '@amsterdam/design-system-css/src/components/paragraph/paragraph.scss';
 @import '@amsterdam/design-system-css/src/components/alert/alert.scss';
 @import '@amsterdam/design-system-css/src/components/row/row.scss';
+@import '@amsterdam/design-system-css/src/components/column/column.scss';
 @import '@amsterdam/design-system-css/src/components/grid/grid.scss';
 @import '@amsterdam/design-system-css/src/components/margin/margin.scss';
 @import '@amsterdam/design-system-css/src/components/link/link.scss';

--- a/src/mocks-server/fixtures/salesforce-afspraken-stadsloket.json
+++ b/src/mocks-server/fixtures/salesforce-afspraken-stadsloket.json
@@ -9,6 +9,12 @@
       "products": [
         {
           "name": "Overheidsloket"
+        },
+        {
+          "name": "Bijstandsaanvraag"
+        },
+        {
+          "name": "BK aanvraag"
         }
       ],
       "location": {

--- a/src/server/services/klantcontact/klantcontact-afspraken.ts
+++ b/src/server/services/klantcontact/klantcontact-afspraken.ts
@@ -1,6 +1,7 @@
 import { fetchSalesforceApi } from './klantcontact-salesforce.ts';
 import type {
   AfspraakFrontend,
+  AfspraakSource,
   AfspraakResponseSource as AfsprakenResponseSource,
 } from './klantcontact.types.ts';
 import { themaConfig } from '../../../client/pages/Thema/KlantContact/KlantContact-thema-config.ts';
@@ -55,12 +56,29 @@ function transformAfsprakenResponse(
       location: `Stadsloket ${result.location.name}, ${result.location.street ?? 'onbekend'}, ${result.location.postalCode} ${result.location.city}, Nederland`,
     });
 
+    function createHeading(
+      products: AfspraakSource['products'],
+      subject: AfspraakSource['subject']
+    ): string {
+      if (products.length > 1) {
+        const productNames = products.map((product) => product.name);
+
+        return new Intl.ListFormat('nl', {
+          style: 'long',
+          type: 'conjunction',
+        }).format(productNames);
+      }
+
+      return subject;
+    }
+
     return {
       dateStart: dateStartISO,
       dateStartFormatted: defaultDateFormat(dateStart),
       dateEnd: dateEndISO,
       dateEndFormatted: defaultDateFormat(dateEnd),
       displayDateTime: `${defaultDateFormatWithDayName(dateStart)} van ${startTime_} tot ${endTime_} uur`,
+      heading: createHeading(result.products, result.subject),
       subject: result.subject,
       products: result.products,
       status: result.status,

--- a/src/server/services/klantcontact/klantcontact-afspraken.ts
+++ b/src/server/services/klantcontact/klantcontact-afspraken.ts
@@ -62,6 +62,7 @@ function transformAfsprakenResponse(
       dateEndFormatted: defaultDateFormat(dateEnd),
       displayDateTime: `${defaultDateFormatWithDayName(dateStart)} van ${startTime_} tot ${endTime_} uur`,
       subject: result.subject,
+      products: result.products,
       status: result.status,
       qrCode: result.qrCode,
       location: result.location,

--- a/src/server/services/klantcontact/klantcontact-afspraken.ts
+++ b/src/server/services/klantcontact/klantcontact-afspraken.ts
@@ -79,8 +79,6 @@ function transformAfsprakenResponse(
       dateEndFormatted: defaultDateFormat(dateEnd),
       displayDateTime: `${defaultDateFormatWithDayName(dateStart)} van ${startTime_} tot ${endTime_} uur`,
       heading: createHeading(result.products, result.subject),
-      subject: result.subject,
-      products: result.products,
       status: result.status,
       qrCode: result.qrCode,
       location: result.location,

--- a/src/server/services/klantcontact/klantcontact.test.ts
+++ b/src/server/services/klantcontact/klantcontact.test.ts
@@ -78,7 +78,7 @@ test('should transform the data correctly', async () => {
     afsprakenResponse: {
       results: [
         {
-          subject: 'Vaarvignet',
+          subject: 'Varen',
           status: 'New',
           startDate: upcomingStartDate,
           endDate: upcomingEndDate,
@@ -86,6 +86,12 @@ test('should transform the data correctly', async () => {
           products: [
             {
               name: 'Vaarvignet',
+            },
+            {
+              name: 'Vaarvergunning',
+            },
+            {
+              name: 'Betaling vaarbewijs',
             },
           ],
           location: {
@@ -127,11 +133,11 @@ test('should transform the data correctly', async () => {
         "dateStart": "2025-01-01T08:00:00.000Z",
         "dateStartFormatted": "01 januari 2025",
         "displayDateTime": "woensdag 01 januari 2025 van 09:00 tot 09:30 uur",
-        "heading": "Vaarvignet",
+        "heading": "Vaarvignet, Vaarvergunning en Betaling vaarbewijs",
         "icsLink": {
           "download": "afspraak-00157784.ics",
           "title": "Voeg toe aan uw privé-agenda",
-          "to": "data:text/calendar;charset=utf-8;base64,QkVHSU4lM0FWQ0FMRU5EQVIlMEQlMEFWRVJTSU9OJTNBMi4wJTBEJTBBUFJPRElEJTNBLSUyRiUyRkFtc3RlcmRhbSUyRiUyRk5PTlNHTUwlMjB2MS4wJTJGJTJGRU4lMEQlMEFCRUdJTiUzQVZFVkVOVCUwRCUwQVVJRCUzQWFmc3ByYWFrLXN0YWRzbG9rZXQtMDAxNTc3ODQlMEQlMEFEVFNUQU1QJTNBMjAyNTAxMDFUMDAwMDAwWiUwRCUwQURUU1RBUlQlM0EyMDI1MDEwMVQwODAwMDBaJTBEJTBBRFRFTkQlM0EyMDI1MDEwMVQwODMwMDBaJTBEJTBBU1VNTUFSWSUzQUFmc3ByYWFrJTIwdm9vciUyMFZhYXJ2aWduZXQlMEQlMEFERVNDUklQVElPTiUzQVJlZmVyZW50aWVudW1tZXIlM0ElMjAwMDE1Nzc4NCUwRCUwQUxPQ0FUSU9OJTNBU3RhZHNsb2tldCUyMFp1aWRvb3N0JTVDJTJDJTIwb25iZWtlbmQlNUMlMkMlMjBudWxsJTIwbnVsbCU1QyUyQyUyME5lZGVybGFuZCUwRCUwQUVORCUzQVZFVkVOVCUwRCUwQUVORCUzQVZDQUxFTkRBUg==",
+          "to": "data:text/calendar;charset=utf-8;base64,QkVHSU4lM0FWQ0FMRU5EQVIlMEQlMEFWRVJTSU9OJTNBMi4wJTBEJTBBUFJPRElEJTNBLSUyRiUyRkFtc3RlcmRhbSUyRiUyRk5PTlNHTUwlMjB2MS4wJTJGJTJGRU4lMEQlMEFCRUdJTiUzQVZFVkVOVCUwRCUwQVVJRCUzQWFmc3ByYWFrLXN0YWRzbG9rZXQtMDAxNTc3ODQlMEQlMEFEVFNUQU1QJTNBMjAyNTAxMDFUMDAwMDAwWiUwRCUwQURUU1RBUlQlM0EyMDI1MDEwMVQwODAwMDBaJTBEJTBBRFRFTkQlM0EyMDI1MDEwMVQwODMwMDBaJTBEJTBBU1VNTUFSWSUzQUFmc3ByYWFrJTIwdm9vciUyMFZhcmVuJTBEJTBBREVTQ1JJUFRJT04lM0FSZWZlcmVudGllbnVtbWVyJTNBJTIwMDAxNTc3ODQlMEQlMEFMT0NBVElPTiUzQVN0YWRzbG9rZXQlMjBadWlkb29zdCU1QyUyQyUyMG9uYmVrZW5kJTVDJTJDJTIwbnVsbCUyMG51bGwlNUMlMkMlMjBOZWRlcmxhbmQlMEQlMEFFTkQlM0FWRVZFTlQlMEQlMEFFTkQlM0FWQ0FMRU5EQVI=",
         },
         "link": {
           "title": "Bekijk afspraak",
@@ -144,14 +150,8 @@ test('should transform the data correctly', async () => {
           "postalCode": null,
           "street": null,
         },
-        "products": [
-          {
-            "name": "Vaarvignet",
-          },
-        ],
         "qrCode": "xxxxxxxxxxxxxxxxxxxx",
         "status": "New",
-        "subject": "Vaarvignet",
       },
     ]
   `);

--- a/src/server/services/klantcontact/klantcontact.test.ts
+++ b/src/server/services/klantcontact/klantcontact.test.ts
@@ -127,6 +127,7 @@ test('should transform the data correctly', async () => {
         "dateStart": "2025-01-01T08:00:00.000Z",
         "dateStartFormatted": "01 januari 2025",
         "displayDateTime": "woensdag 01 januari 2025 van 09:00 tot 09:30 uur",
+        "heading": "Vaarvignet",
         "icsLink": {
           "download": "afspraak-00157784.ics",
           "title": "Voeg toe aan uw privé-agenda",

--- a/src/server/services/klantcontact/klantcontact.test.ts
+++ b/src/server/services/klantcontact/klantcontact.test.ts
@@ -143,6 +143,11 @@ test('should transform the data correctly', async () => {
           "postalCode": null,
           "street": null,
         },
+        "products": [
+          {
+            "name": "Vaarvignet",
+          },
+        ],
         "qrCode": "xxxxxxxxxxxxxxxxxxxx",
         "status": "New",
         "subject": "Vaarvignet",

--- a/src/server/services/klantcontact/klantcontact.types.ts
+++ b/src/server/services/klantcontact/klantcontact.types.ts
@@ -65,6 +65,7 @@ export type AfspraakFrontend = Omit<AfspraakSource, 'startDate' | 'endDate'> & {
   displayDateTime: string;
   link: LinkProps;
   icsLink: LinkProps;
+  heading: string;
 };
 
 export type KlantcontactResponseData = {

--- a/src/server/services/klantcontact/klantcontact.types.ts
+++ b/src/server/services/klantcontact/klantcontact.types.ts
@@ -57,7 +57,10 @@ export type AfspraakResponseSource = {
   count: number;
 };
 
-export type AfspraakFrontend = Omit<AfspraakSource, 'startDate' | 'endDate'> & {
+export type AfspraakFrontend = Omit<
+  AfspraakSource,
+  'startDate' | 'endDate' | 'subject' | 'products'
+> & {
   dateStart: string;
   dateStartFormatted: string;
   dateEnd: string;

--- a/src/server/services/klantcontact/klantcontact.types.ts
+++ b/src/server/services/klantcontact/klantcontact.types.ts
@@ -57,10 +57,7 @@ export type AfspraakResponseSource = {
   count: number;
 };
 
-export type AfspraakFrontend = Omit<
-  AfspraakSource,
-  'startDate' | 'endDate' | 'products'
-> & {
+export type AfspraakFrontend = Omit<AfspraakSource, 'startDate' | 'endDate'> & {
   dateStart: string;
   dateStartFormatted: string;
   dateEnd: string;


### PR DESCRIPTION
Deze PR verbetert de `AfsprakenCard` op drie punten:

**1. Meerdere onderwerpen per afspraak**
De AfsprakenCard ondersteunt nu afspraken met meerdere onderwerpen.
Deze onderwerpen worden getoond in de titel van de kaart.

**2. Verbeterde mobiele weergave**

**3. Bijgewerkt icoon voor afspraken en thema Contact met de Gemeente**
Het icoon sluit nu aan op het design.

### Afbeeldingen

Dashboard

<img width="810" height="602" alt="image" src="https://github.com/user-attachments/assets/67e4d27d-d6de-4c5c-b9a1-843e614069b5" />

Listpage Desktop

<img width="1270" height="888" alt="image" src="https://github.com/user-attachments/assets/7ebd86ce-790b-48c8-a259-0ad4d5a44ff7" />

Listpage Mobile 

<img width="396" height="778" alt="image" src="https://github.com/user-attachments/assets/9e82d2d1-bbba-4aae-b337-4eaa841d8675" />

Themapagina

<img width="880" height="890" alt="image" src="https://github.com/user-attachments/assets/943779e3-e605-45db-abd9-1e326183f7ef" />

