### PR TITLE
MIJN-12798-BUG: Safari blocking requests

### DIFF
--- a/src/client/hooks/api/useSessionApi.ts
+++ b/src/client/hooks/api/useSessionApi.ts
@@ -32,7 +32,12 @@ export function useSessionApi() {
     const checkAway = () => {
       if (document.body.classList.contains('is-away')) {
         document.body.classList.remove('is-away');
-        fetch();
+        // Fetching immediately causes Safari IOS to block the request when coming back (focus) from a download dialog.
+        // This causes the user to appear logged out, even though the session is still valid.
+        // Delaying the fetch with a setTimeout somehow prevents this from happening.
+        setTimeout(() => {
+          fetch();
+        }, 0);
       }
     };
 

--- a/src/client/hooks/api/useSessionApi.ts
+++ b/src/client/hooks/api/useSessionApi.ts
@@ -37,7 +37,7 @@ export function useSessionApi() {
         // Delaying the fetch with a setTimeout somehow prevents this from happening.
         setTimeout(() => {
           fetch();
-        }, 0);
+        }, 10);
       }
     };
 

--- a/src/client/hooks/api/useSessionApi.ts
+++ b/src/client/hooks/api/useSessionApi.ts
@@ -29,19 +29,21 @@ export function useSessionApi() {
   }, [setProfileType, sessionData?.profileType]);
 
   useEffect(() => {
+    let fetchTimeout: ReturnType<typeof setTimeout>;
     const checkAway = () => {
       if (document.body.classList.contains('is-away')) {
         document.body.classList.remove('is-away');
         // Fetching immediately causes Safari IOS to block the request when coming back (focus) from a download dialog.
         // This causes the user to appear logged out, even though the session is still valid.
         // Delaying the fetch with a setTimeout somehow prevents this from happening.
-        setTimeout(() => {
+        fetchTimeout = setTimeout(() => {
           fetch();
         }, 10);
       }
     };
 
     const addAway = () => {
+      clearTimeout(fetchTimeout);
       document.body.classList.add('is-away');
     };
 
@@ -49,6 +51,7 @@ export function useSessionApi() {
     window.addEventListener('blur', addAway);
 
     return () => {
+      clearTimeout(fetchTimeout);
       window.removeEventListener('focus', checkAway);
       window.removeEventListener('blur', addAway);
     };


### PR DESCRIPTION
When dismissing the dialog on IOS a focus event is fired which makes a fetch call to the auth/check endpoint. Somehow this request is blocked. Adding a little delay to the fetch fixes this issue.